### PR TITLE
Add thread creation span management to ResCreationSpanManagementService

### DIFF
--- a/eddist-server/src/domain/service/res_creation_span_management_service.rs
+++ b/eddist-server/src/domain/service/res_creation_span_management_service.rs
@@ -4,11 +4,16 @@ use redis::{aio::ConnectionManager, AsyncCommands};
 pub struct ResCreationSpanManagementService {
     redis_conn: ConnectionManager,
     span: u64,
+    thread_span: u64,
 }
 
 impl ResCreationSpanManagementService {
-    pub fn new(redis_conn: ConnectionManager, span: u64) -> Self {
-        Self { redis_conn, span }
+    pub fn new(redis_conn: ConnectionManager, span: u64, thread_span: u64) -> Self {
+        Self {
+            redis_conn,
+            span,
+            thread_span,
+        }
     }
 
     /// Check if the timestamp is within the creation restriction span for the given authed token or ip address.
@@ -96,6 +101,99 @@ impl ResCreationSpanManagementService {
         let key = format!("res_creation_span_ip:{ip}");
         redis_conn
             .set_ex::<_, _, ()>(key, timestamp, self.span)
+            .await
+            .unwrap();
+    }
+
+    /// Check if the timestamp is within the thread creation restriction span for the given authed token or ip address.
+    pub async fn is_thread_within_creation_span(
+        &self,
+        authed_token: &str,
+        ip_adr: &str,
+        timestamp: u64,
+    ) -> bool {
+        self.is_within_thread_creation_span_by_authed_token(authed_token, timestamp)
+            .await
+            || self
+                .is_within_thread_creation_span_by_ip(ip_adr, timestamp)
+                .await
+    }
+
+    /// Check if the timestamp is within the thread creation restriction span for the given authed token.
+    async fn is_within_thread_creation_span_by_authed_token(
+        &self,
+        authed_token: &str,
+        timestamp: u64,
+    ) -> bool {
+        if self.thread_span == 0 {
+            return false;
+        }
+
+        let mut redis_conn = self.redis_conn.clone();
+
+        let key = format!("thread_creation_span:{authed_token}");
+        let before_res_time = redis_conn.get::<_, u64>(&key).await.unwrap_or(0);
+
+        timestamp - before_res_time < self.thread_span
+    }
+
+    /// Check if the timestamp is within the thread creation restriction span for the given ip address.
+    async fn is_within_thread_creation_span_by_ip(&self, ip: &str, timestamp: u64) -> bool {
+        if self.thread_span == 0 {
+            return false;
+        }
+
+        let mut redis_conn = self.redis_conn.clone();
+
+        let key = format!("thread_creation_span_ip:{ip}");
+        let before_res_time = redis_conn.get::<_, u64>(&key).await.unwrap_or(0);
+
+        timestamp - before_res_time < self.thread_span
+    }
+
+    /// Update the last thread creation time for the given authed token and ip address.
+    pub async fn update_last_thread_creation_time(
+        &self,
+        authed_token: &str,
+        ip: &str,
+        timestamp: u64,
+    ) {
+        self.update_last_thread_creation_time_authed_token(authed_token, timestamp)
+            .await;
+        self.update_last_thread_creation_time_by_ip(ip, timestamp)
+            .await;
+    }
+
+    /// Update the last thread creation time for the given authed token.
+    async fn update_last_thread_creation_time_authed_token(
+        &self,
+        authed_token: &str,
+        timestamp: u64,
+    ) {
+        if self.thread_span == 0 {
+            return;
+        }
+
+        let mut redis_conn = self.redis_conn.clone();
+
+        let key = format!("res_creation_span:{authed_token}");
+        redis_conn
+            .set_ex::<_, _, ()>(key, timestamp, self.thread_span)
+            .await
+            .unwrap();
+    }
+
+    /// Update the last thread creation time for the given ip address.
+    async fn update_last_thread_creation_time_by_ip(&self, ip: &str, timestamp: u64) {
+        if self.thread_span == 0 {
+            return;
+        }
+
+        let mut redis_conn = self.redis_conn.clone();
+
+        let key = format!("res_creation_span_ip:{ip}");
+        redis_conn
+            .set_ex::<_, _, ()>(key, timestamp, self.thread_span)
             .await
             .unwrap();
     }

--- a/eddist-server/src/error.rs
+++ b/eddist-server/src/error.rs
@@ -56,6 +56,9 @@ pub enum BbsCgiError {
     #[error("短期間にスレ立てすぎです (Lv{tinker_level}は{span_sec}秒以内に1回スレを立てることができます)")]
     TooManyCreatingThread { tinker_level: u32, span_sec: i32 },
 
+    #[error("短期間にスレ立てすぎです")]
+    TooManyCreatingThreadWithoutTinker,
+
     #[error("初回書き込み時にはスレッドを立てることができません")]
     TmpCanNotCreateThread,
 
@@ -82,6 +85,7 @@ impl BbsCgiError {
             BbsCgiError::ContentEmpty(_) => StatusCode::OK,
             BbsCgiError::TooManyCreatingRes(_) => StatusCode::OK,
             BbsCgiError::TooManyCreatingThread { .. } => StatusCode::OK,
+            BbsCgiError::TooManyCreatingThreadWithoutTinker => StatusCode::OK,
             BbsCgiError::TmpCanNotCreateThread => StatusCode::OK,
             BbsCgiError::ReadOnlyBoard => StatusCode::OK,
             BbsCgiError::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -103,6 +107,7 @@ impl BbsCgiError {
             BbsCgiError::ContentEmpty(_) => "ContentEmpty",
             BbsCgiError::TooManyCreatingRes(_) => "TooManyCreatingRes",
             BbsCgiError::TooManyCreatingThread { .. } => "TooManyCreatingThread",
+            BbsCgiError::TooManyCreatingThreadWithoutTinker => "TooManyCreatingThreadWithoutTinker",
             BbsCgiError::TmpCanNotCreateThread => "TmpCanNotCreateThread",
             BbsCgiError::ReadOnlyBoard => "ReadOnlyBoard",
             BbsCgiError::Other(_) => "InternalError",

--- a/eddist-server/src/services/res_creation_service.rs
+++ b/eddist-server/src/services/res_creation_service.rs
@@ -135,6 +135,7 @@ impl<T: BbsRepository + Clone, P: PubRepository>
         let res_span_svc = ResCreationSpanManagementService::new(
             redis_conn.clone(),
             board_info.base_response_creation_span_sec as u64,
+            board_info.base_thread_creation_span_sec as u64, // ignorable
         );
         if res_span_svc
             .is_within_creation_span(

--- a/eddist-server/src/services/thread_creation_service.rs
+++ b/eddist-server/src/services/thread_creation_service.rs
@@ -139,6 +139,7 @@ impl<T: BbsRepository + Clone>
         let res_span_svc = ResCreationSpanManagementService::new(
             redis_conn.clone(),
             board_info.base_response_creation_span_sec as u64,
+            board_info.base_thread_creation_span_sec as u64,
         );
         if res_span_svc
             .is_within_creation_span(&authed_token.token, &input.ip_addr, unix_time as u64)
@@ -148,6 +149,13 @@ impl<T: BbsRepository + Clone>
                 board_info.base_response_creation_span_sec,
             ));
         };
+        if res_span_svc
+            .is_thread_within_creation_span(&authed_token.token, &input.ip_addr, unix_time as u64)
+            .await
+        {
+            return Err(BbsCgiError::TooManyCreatingThreadWithoutTinker);
+        }
+
         let ng_words = NgWordReadingService::new(self.0.clone(), redis_conn.clone())
             .get_ng_words(&input.board_key)
             .await?;
@@ -174,6 +182,13 @@ impl<T: BbsRepository + Clone>
                 .await?;
             res_span_svc
                 .update_last_res_creation_time(
+                    &authed_token_clone,
+                    &input.ip_addr,
+                    unix_time as u64,
+                )
+                .await;
+            res_span_svc
+                .update_last_thread_creation_time(
                     &authed_token_clone,
                     &input.ip_addr,
                     unix_time as u64,


### PR DESCRIPTION
## Abstract

- Introduced thread_span field to manage thread creation restrictions.
- Implemented methods to check and update thread creation times based on authed token and IP address.
- Updated ResCreationService and ThreadCreationService to utilize new thread creation span functionality.