### PR TITLE
feat: Implement user restriction rules management

### DIFF
--- a/.sqlx/query-01da262d52a8c57a194a713d9b4bbbfe85a0d9761432ad22d3968433728a1c10.json
+++ b/.sqlx/query-01da262d52a8c57a194a713d9b4bbbfe85a0d9761432ad22d3968433728a1c10.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "MySQL",
+  "query": "\n            SELECT \n                BIN_TO_UUID(id) as id,\n                name,\n                rule_type,\n                rule_value,\n                expires_at,\n                created_at,\n                updated_at,\n                created_by_email\n            FROM user_restriction_rules\n            WHERE expires_at IS NULL OR expires_at > NOW()\n            ORDER BY created_at DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "VarString",
+          "flags": "",
+          "max_size": 144
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": {
+          "type": "VarString",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "max_size": 1020
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "rule_type",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | MULTIPLE_KEY | ENUM | NO_DEFAULT_VALUE",
+          "max_size": 40
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "rule_value",
+        "type_info": {
+          "type": "Blob",
+          "flags": "NOT_NULL | BLOB | NO_DEFAULT_VALUE",
+          "max_size": 262140
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "expires_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "MULTIPLE_KEY | BINARY",
+          "max_size": 23
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "NOT_NULL | MULTIPLE_KEY | BINARY | NO_DEFAULT_VALUE",
+          "max_size": 23
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
+          "max_size": 23
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_by_email",
+        "type_info": {
+          "type": "VarString",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "max_size": 1020
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "01da262d52a8c57a194a713d9b4bbbfe85a0d9761432ad22d3968433728a1c10"
+}

--- a/.sqlx/query-25c6d268ec0af503103d24e8b92d5cfe740af5902727b45c93b4a638db70f331.json
+++ b/.sqlx/query-25c6d268ec0af503103d24e8b92d5cfe740af5902727b45c93b4a638db70f331.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "\n                UPDATE user_restriction_rules \n                SET name = ?, rule_type = ?, rule_value = ?, expires_at = ?, updated_at = ?\n                WHERE id = UUID_TO_BIN(?)\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 6
+    },
+    "nullable": []
+  },
+  "hash": "25c6d268ec0af503103d24e8b92d5cfe740af5902727b45c93b4a638db70f331"
+}

--- a/.sqlx/query-608b4031d229939727371579b48cd01bfaec7219507437e809b627cb7946094b.json
+++ b/.sqlx/query-608b4031d229939727371579b48cd01bfaec7219507437e809b627cb7946094b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "\n            INSERT INTO user_restriction_rules \n            (id, name, rule_type, rule_value, expires_at, created_at, updated_at, created_by_email)\n            VALUES (UUID_TO_BIN(?), ?, ?, ?, ?, ?, ?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 8
+    },
+    "nullable": []
+  },
+  "hash": "608b4031d229939727371579b48cd01bfaec7219507437e809b627cb7946094b"
+}

--- a/.sqlx/query-bbfaada1bc901afed80af734b1251fc07fae70d19351677d45803c11a2a3ac08.json
+++ b/.sqlx/query-bbfaada1bc901afed80af734b1251fc07fae70d19351677d45803c11a2a3ac08.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM user_restriction_rules WHERE id = UUID_TO_BIN(?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "bbfaada1bc901afed80af734b1251fc07fae70d19351677d45803c11a2a3ac08"
+}

--- a/.sqlx/query-bfdfadcd9948688b1a41559a1d049cb7596104a55213c4d0a9557f187ddb3031.json
+++ b/.sqlx/query-bfdfadcd9948688b1a41559a1d049cb7596104a55213c4d0a9557f187ddb3031.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "MySQL",
+  "query": "\n            SELECT \n                BIN_TO_UUID(id) as id,\n                name,\n                rule_type,\n                rule_value,\n                expires_at,\n                created_at,\n                updated_at,\n                created_by_email\n            FROM user_restriction_rules\n            ORDER BY created_at DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "VarString",
+          "flags": "",
+          "max_size": 144
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": {
+          "type": "VarString",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "max_size": 1020
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "rule_type",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | MULTIPLE_KEY | ENUM | NO_DEFAULT_VALUE",
+          "max_size": 40
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "rule_value",
+        "type_info": {
+          "type": "Blob",
+          "flags": "NOT_NULL | BLOB | NO_DEFAULT_VALUE",
+          "max_size": 262140
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "expires_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "MULTIPLE_KEY | BINARY",
+          "max_size": 23
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "NOT_NULL | MULTIPLE_KEY | BINARY | NO_DEFAULT_VALUE",
+          "max_size": 23
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
+          "max_size": 23
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_by_email",
+        "type_info": {
+          "type": "VarString",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "max_size": 1020
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "bfdfadcd9948688b1a41559a1d049cb7596104a55213c4d0a9557f187ddb3031"
+}

--- a/.sqlx/query-e6b42eec611bdd70b7fb9e5f20665e9b0aeb7cd85542fac1cb60a2d232a76b55.json
+++ b/.sqlx/query-e6b42eec611bdd70b7fb9e5f20665e9b0aeb7cd85542fac1cb60a2d232a76b55.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "MySQL",
+  "query": "\n            SELECT \n                BIN_TO_UUID(id) as id,\n                name,\n                rule_type,\n                rule_value,\n                expires_at,\n                created_at,\n                updated_at,\n                created_by_email\n            FROM user_restriction_rules\n            WHERE id = UUID_TO_BIN(?)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "VarString",
+          "flags": "",
+          "max_size": 144
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": {
+          "type": "VarString",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "max_size": 1020
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "rule_type",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | MULTIPLE_KEY | ENUM | NO_DEFAULT_VALUE",
+          "max_size": 40
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "rule_value",
+        "type_info": {
+          "type": "Blob",
+          "flags": "NOT_NULL | BLOB | NO_DEFAULT_VALUE",
+          "max_size": 262140
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "expires_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "MULTIPLE_KEY | BINARY",
+          "max_size": 23
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "NOT_NULL | MULTIPLE_KEY | BINARY | NO_DEFAULT_VALUE",
+          "max_size": 23
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
+          "max_size": 23
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_by_email",
+        "type_info": {
+          "type": "VarString",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "max_size": 1020
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e6b42eec611bdd70b7fb9e5f20665e9b0aeb7cd85542fac1cb60a2d232a76b55"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "encoding_rs",
+ "ipnet",
  "metrics",
  "redis",
  "serde",

--- a/eddist-admin/client/app/hooks/queries.ts
+++ b/eddist-admin/client/app/hooks/queries.ts
@@ -528,3 +528,93 @@ export const updateUserStatus = ({
   };
   return { mutate };
 };
+
+const GET_RESTRICTION_RULES = "/restriction_rules";
+
+export const getRestrictionRules = ({
+  params,
+}: UseQueryOptions<paths[typeof GET_RESTRICTION_RULES]["get"]>) => {
+  return useSuspenseQuery({
+    queryKey: [GET_RESTRICTION_RULES],
+    queryFn: async ({ signal }) => {
+      const { data } = await client.GET(GET_RESTRICTION_RULES, {
+        params,
+        signal,
+      });
+
+      if (data) {
+        data.sort((a, b) => {
+          if (a.created_at < b.created_at) {
+            return 1;
+          }
+          if (a.created_at > b.created_at) {
+            return -1;
+          }
+          return 0;
+        });
+      }
+
+      return data;
+    },
+  });
+};
+
+const CREATE_RESTRICTION_RULE = "/restriction_rules";
+
+export const createRestrictionRule = ({
+  body,
+}: UseQueryOptions<paths[typeof CREATE_RESTRICTION_RULE]["post"]>) => {
+  const mutate = async () => {
+    await client.POST(CREATE_RESTRICTION_RULE, {
+      body,
+    });
+  };
+  return { mutate };
+};
+
+const GET_RESTRICTION_RULE = "/restriction_rules/{rule_id}";
+
+export const getRestrictionRule = ({
+  params,
+  reactQuery,
+}: UseQueryOptions<paths[typeof GET_RESTRICTION_RULE]["get"]>) => {
+  return useSuspenseQuery({
+    ...reactQuery,
+    queryKey: [GET_RESTRICTION_RULE, params.path.rule_id],
+    queryFn: async ({ signal }) => {
+      const { data } = await client.GET(GET_RESTRICTION_RULE, {
+        params,
+        signal,
+      });
+      return data;
+    },
+  });
+};
+
+const UPDATE_RESTRICTION_RULE = "/restriction_rules/{rule_id}";
+
+export const updateRestrictionRule = ({
+  params,
+  body,
+}: UseQueryOptions<paths[typeof UPDATE_RESTRICTION_RULE]["patch"]>) => {
+  const mutate = async () => {
+    await client.PATCH(UPDATE_RESTRICTION_RULE, {
+      params,
+      body,
+    });
+  };
+  return { mutate };
+};
+
+const DELETE_RESTRICTION_RULE = "/restriction_rules/{rule_id}";
+
+export const deleteRestrictionRule = ({
+  params,
+}: UseQueryOptions<paths[typeof DELETE_RESTRICTION_RULE]["delete"]>) => {
+  const mutate = async () => {
+    await client.DELETE(DELETE_RESTRICTION_RULE, {
+      params,
+    });
+  };
+  return { mutate };
+};

--- a/eddist-admin/client/app/openapi/schema.d.ts
+++ b/eddist-admin/client/app/openapi/schema.d.ts
@@ -324,6 +324,38 @@ export interface paths {
         patch: operations["update_ng_word"];
         trace?: never;
     };
+    "/restriction_rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_restriction_rules"];
+        put?: never;
+        post: operations["create_restriction_rule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/restriction_rules/{rule_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_restriction_rule"];
+        put?: never;
+        post?: never;
+        delete: operations["delete_restriction_rule"];
+        options?: never;
+        head?: never;
+        patch: operations["update_restriction_rule"];
+        trace?: never;
+    };
     "/users/search/": {
         parameters: {
             query?: never;
@@ -447,7 +479,7 @@ export interface components {
             /** Format: int32 */
             asn_num: number;
             ip_addr: string;
-            tinker?: components["schemas"]["Tinker"] | null;
+            tinker?: null | components["schemas"]["Tinker"];
             user_agent: string;
         };
         CreateBoardInput: {
@@ -464,6 +496,13 @@ export interface components {
             name: string;
             threads_archive_cron?: string | null;
             threads_archive_trigger_thread_count?: number | null;
+        };
+        CreateRestrictionRuleRequest: {
+            /** Format: date-time */
+            expires_at?: string | null;
+            name: string;
+            rule_type: string;
+            rule_value: string;
         };
         CreationCapInput: {
             description: string;
@@ -521,6 +560,8 @@ export interface components {
             /** Format: uuid */
             thread_id: string;
         };
+        /** @enum {string} */
+        RestrictionRuleTypeSchema: "ASN" | "IP" | "IPCidr" | "UserAgent";
         Thread: {
             active: boolean;
             archived: boolean;
@@ -578,6 +619,13 @@ export interface components {
             is_abone?: boolean | null;
             mail?: string | null;
         };
+        UpdateRestrictionRuleRequest: {
+            /** Format: date-time */
+            expires_at?: string | null;
+            name?: string | null;
+            rule_type?: string | null;
+            rule_value?: string | null;
+        };
         User: {
             authed_token_ids: string[];
             enabled: boolean;
@@ -593,6 +641,19 @@ export interface components {
             idp_sub: string;
             /** Format: uuid */
             user_id: string;
+        };
+        UserRestrictionRuleSchema: {
+            /** Format: date-time */
+            created_at: string;
+            created_by_email: string;
+            /** Format: date-time */
+            expires_at?: string | null;
+            id: string;
+            name: string;
+            rule_type: components["schemas"]["RestrictionRuleTypeSchema"];
+            rule_value: string;
+            /** Format: date-time */
+            updated_at: string;
         };
         UserStatusUpdateInput: {
             enabled: boolean;
@@ -1324,6 +1385,119 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["NgWord"];
                 };
+            };
+        };
+    };
+    get_restriction_rules: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List all restriction rules */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserRestrictionRuleSchema"][];
+                };
+            };
+        };
+    };
+    create_restriction_rule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateRestrictionRuleRequest"];
+            };
+        };
+        responses: {
+            /** @description Create restriction rule */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserRestrictionRuleSchema"];
+                };
+            };
+        };
+    };
+    get_restriction_rule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Rule ID */
+                rule_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get restriction rule by ID */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserRestrictionRuleSchema"];
+                };
+            };
+        };
+    };
+    delete_restriction_rule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Rule ID */
+                rule_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete restriction rule */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    update_restriction_rule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Rule ID */
+                rule_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateRestrictionRuleRequest"];
+            };
+        };
+        responses: {
+            /** @description Update restriction rule */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/eddist-admin/client/app/routes/dashboard.restriction-rules.tsx
+++ b/eddist-admin/client/app/routes/dashboard.restriction-rules.tsx
@@ -1,0 +1,406 @@
+import {
+  Button,
+  Dropdown,
+  Label,
+  Modal,
+  Table,
+  TextInput,
+  Select,
+  Checkbox,
+} from "flowbite-react";
+import { useState } from "react";
+import { BiDotsHorizontalRounded } from "react-icons/bi";
+import { FaPlus } from "react-icons/fa";
+import { Controller, useForm } from "react-hook-form";
+import {
+  deleteRestrictionRule,
+  getRestrictionRules,
+  updateRestrictionRule,
+  createRestrictionRule,
+} from "~/hooks/queries";
+import { toast } from "react-toastify";
+
+interface RestrictionRule {
+  id: string;
+  name: string;
+  rule_type: "ASN" | "IP" | "IPCidr" | "UserAgent";
+  rule_value: string;
+  expires_at?: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by_email: string;
+}
+
+interface CreateRestrictionRuleForm {
+  name: string;
+  rule_type: "ASN" | "IP" | "IPCidr" | "UserAgent";
+  rule_value: string;
+  expires_at?: string;
+}
+
+interface EditRestrictionRuleForm {
+  id: string;
+  name: string;
+  rule_type: "ASN" | "IP" | "IPCidr" | "UserAgent";
+  rule_value: string;
+  expires_at?: string;
+}
+
+const RestrictionRules = () => {
+  const { data: restrictionRules, refetch } = getRestrictionRules({});
+  const [openCreateModal, setOpenCreateModal] = useState(false);
+  const [openEditModal, setOpenEditModal] = useState(false);
+  const [selectedRule, setSelectedRule] = useState<RestrictionRule | undefined>(
+    undefined
+  );
+  const [createNeverExpires, setCreateNeverExpires] = useState(true);
+  const [editNeverExpires, setEditNeverExpires] = useState(true);
+  const {
+    register: registerCreate,
+    handleSubmit: handleSubmitCreate,
+    control: controlCreate,
+    reset: resetCreate,
+  } = useForm<CreateRestrictionRuleForm>();
+  const {
+    register: registerEdit,
+    handleSubmit: handleSubmitEdit,
+    control: controlEdit,
+    reset: resetEdit,
+  } = useForm<EditRestrictionRuleForm>();
+
+  const ruleTypeOptions = [
+    { value: "ASN", label: "ASN" },
+    { value: "IP", label: "IP Address" },
+    { value: "IPCidr", label: "IP CIDR" },
+    { value: "UserAgent", label: "User Agent" },
+  ];
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleString();
+  };
+
+  const formatExpiry = (expiresAt?: string | null) => {
+    if (!expiresAt) return "Never";
+    const expiry = new Date(expiresAt);
+    const now = new Date();
+    if (expiry < now) return "Expired";
+    return expiry.toLocaleString();
+  };
+
+  return (
+    <>
+      <Modal
+        show={openCreateModal}
+        onClose={() => {
+          resetCreate();
+          setCreateNeverExpires(true);
+          setOpenCreateModal(false);
+        }}
+      >
+        <Modal.Header>Create Restriction Rule</Modal.Header>
+        <Modal.Body>
+          <form
+            onSubmit={handleSubmitCreate(async (data) => {
+              try {
+                const { mutate } = createRestrictionRule({
+                  body: {
+                    name: data.name,
+                    rule_type: data.rule_type,
+                    rule_value: data.rule_value,
+                    expires_at: createNeverExpires || !data.expires_at
+                      ? undefined
+                      : new Date(data.expires_at).toISOString(),
+                  },
+                });
+                await mutate();
+                setOpenCreateModal(false);
+                resetCreate();
+                setCreateNeverExpires(true);
+                toast.success("Successfully created restriction rule");
+                await refetch();
+              } catch (e) {
+                toast.error("Failed to create restriction rule");
+              }
+            })}
+          >
+            <div className="flex flex-col space-y-4">
+              <div>
+                <Label>Name</Label>
+                <TextInput
+                  placeholder="Rule name..."
+                  required
+                  {...registerCreate("name", { required: true })}
+                />
+              </div>
+              <div>
+                <Label>Rule Type</Label>
+                <Controller
+                  name="rule_type"
+                  control={controlCreate}
+                  rules={{ required: true }}
+                  render={({ field }) => (
+                    <Select
+                      required
+                      value={field.value}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    >
+                      <option value="">Select rule type...</option>
+                      {ruleTypeOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </Select>
+                  )}
+                />
+              </div>
+              <div>
+                <Label>Rule Value</Label>
+                <TextInput
+                  placeholder="Rule value..."
+                  required
+                  {...registerCreate("rule_value", { required: true })}
+                />
+              </div>
+              <div>
+                <div className="flex items-center space-x-2 mb-3">
+                  <Checkbox
+                    id="create-never-expires"
+                    checked={createNeverExpires}
+                    onChange={(e) => setCreateNeverExpires(e.target.checked)}
+                  />
+                  <Label htmlFor="create-never-expires">Never expires</Label>
+                </div>
+                {!createNeverExpires && (
+                  <div>
+                    <Label>Expires At</Label>
+                    <TextInput
+                      type="datetime-local"
+                      {...registerCreate("expires_at")}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+            <Button type="submit" className="mt-4">
+              Create Rule
+            </Button>
+          </form>
+        </Modal.Body>
+      </Modal>
+
+      <Modal
+        show={openEditModal}
+        onClose={() => {
+          resetEdit();
+          setEditNeverExpires(true);
+          setOpenEditModal(false);
+        }}
+      >
+        <Modal.Header>Edit Restriction Rule</Modal.Header>
+        <Modal.Body>
+          <form
+            onSubmit={handleSubmitEdit(async (data) => {
+              try {
+                const { mutate } = updateRestrictionRule({
+                  params: {
+                    path: {
+                      rule_id: selectedRule!.id,
+                    },
+                  },
+                  body: {
+                    name: data.name,
+                    rule_type: data.rule_type,
+                    rule_value: data.rule_value,
+                    expires_at: editNeverExpires || !data.expires_at
+                      ? undefined
+                      : new Date(data.expires_at).toISOString(),
+                  },
+                });
+                await mutate();
+                setOpenEditModal(false);
+                resetEdit();
+                setEditNeverExpires(true);
+                toast.success("Successfully updated restriction rule");
+                await refetch();
+              } catch (e) {
+                toast.error("Failed to update restriction rule");
+              }
+            })}
+          >
+            <div className="flex flex-col space-y-4">
+              <input
+                type="hidden"
+                {...registerEdit("id")}
+                value={selectedRule?.id}
+              />
+              <div>
+                <Label>Name</Label>
+                <TextInput
+                  placeholder="Rule name..."
+                  required
+                  defaultValue={selectedRule?.name}
+                  {...registerEdit("name", { required: true })}
+                />
+              </div>
+              <div>
+                <Label>Rule Type</Label>
+                <Controller
+                  name="rule_type"
+                  control={controlEdit}
+                  rules={{ required: true }}
+                  defaultValue={selectedRule?.rule_type}
+                  render={({ field }) => (
+                    <Select
+                      required
+                      value={field.value}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    >
+                      <option value="">Select rule type...</option>
+                      {ruleTypeOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </Select>
+                  )}
+                />
+              </div>
+              <div>
+                <Label>Rule Value</Label>
+                <TextInput
+                  placeholder="Rule value..."
+                  required
+                  defaultValue={selectedRule?.rule_value}
+                  {...registerEdit("rule_value", { required: true })}
+                />
+              </div>
+              <div>
+                <div className="flex items-center space-x-2 mb-3">
+                  <Checkbox
+                    id="edit-never-expires"
+                    checked={editNeverExpires}
+                    onChange={(e) => setEditNeverExpires(e.target.checked)}
+                  />
+                  <Label htmlFor="edit-never-expires">Never expires</Label>
+                </div>
+                {!editNeverExpires && (
+                  <div>
+                    <Label>Expires At</Label>
+                    <TextInput
+                      type="datetime-local"
+                      defaultValue={
+                        selectedRule?.expires_at
+                          ? new Date(selectedRule.expires_at)
+                              .toISOString()
+                              .slice(0, 16)
+                          : ""
+                      }
+                      {...registerEdit("expires_at")}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+            <Button type="submit" className="mt-4">
+              Update Rule
+            </Button>
+          </form>
+        </Modal.Body>
+      </Modal>
+
+      <div className="p-2 lg:p-8">
+        <div className="flex">
+          <h1 className="text-3xl font-bold flex-grow">Restriction Rules</h1>
+          <button
+            className="mr-2 bg-slate-400 p-4 rounded-xl shadow-lg hover:bg-slate-500"
+            onClick={() => setOpenCreateModal(true)}
+          >
+            <FaPlus />
+          </button>
+        </div>
+        <Table className="mt-4">
+          <Table.Head>
+            <Table.HeadCell>Name</Table.HeadCell>
+            <Table.HeadCell>Type</Table.HeadCell>
+            <Table.HeadCell>Value</Table.HeadCell>
+            <Table.HeadCell>Expires</Table.HeadCell>
+            <Table.HeadCell>Created By</Table.HeadCell>
+            <Table.HeadCell>Created At</Table.HeadCell>
+            <Table.HeadCell></Table.HeadCell>
+          </Table.Head>
+          <Table.Body className="divide-y">
+            {restrictionRules?.map((rule) => (
+              <Table.Row key={rule.id}>
+                <Table.Cell className="font-medium">{rule.name}</Table.Cell>
+                <Table.Cell>
+                  <span className="px-2 py-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-800">
+                    {rule.rule_type}
+                  </span>
+                </Table.Cell>
+                <Table.Cell className="font-mono text-sm">
+                  {rule.rule_value}
+                </Table.Cell>
+                <Table.Cell>
+                  <span
+                    className={`px-2 py-1 text-xs font-semibold rounded-full ${
+                      rule.expires_at
+                        ? new Date(rule.expires_at) < new Date()
+                          ? "bg-red-100 text-red-800"
+                          : "bg-yellow-100 text-yellow-800"
+                        : "bg-green-100 text-green-800"
+                    }`}
+                  >
+                    {formatExpiry(rule.expires_at)}
+                  </span>
+                </Table.Cell>
+                <Table.Cell>{rule.created_by_email}</Table.Cell>
+                <Table.Cell>{formatDate(rule.created_at)}</Table.Cell>
+                <Table.Cell>
+                  <div className="text-right">
+                    <Dropdown label={<BiDotsHorizontalRounded />}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          setOpenEditModal(true);
+                          setSelectedRule(rule);
+                          setEditNeverExpires(!rule.expires_at);
+                        }}
+                      >
+                        Edit
+                      </Dropdown.Item>
+                      <Dropdown.Item
+                        className="text-red-500"
+                        onClick={async () => {
+                          try {
+                            const { mutate } = deleteRestrictionRule({
+                              params: {
+                                path: {
+                                  rule_id: rule.id,
+                                },
+                              },
+                            });
+                            await mutate();
+                            toast.success(
+                              "Successfully deleted restriction rule"
+                            );
+                            await refetch();
+                          } catch (e) {
+                            toast.error("Failed to delete restriction rule");
+                          }
+                        }}
+                      >
+                        Delete
+                      </Dropdown.Item>
+                    </Dropdown>
+                  </div>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </div>
+    </>
+  );
+};
+
+export default RestrictionRules;

--- a/eddist-admin/client/app/routes/dashboard.tsx
+++ b/eddist-admin/client/app/routes/dashboard.tsx
@@ -10,7 +10,8 @@ type NavBarSectionKind =
   | "ngwords"
   | "global"
   | "authed-token"
-  | "users";
+  | "users"
+  | "restriction-rules";
 
 const Hamburger = () => (
   <svg
@@ -54,6 +55,9 @@ const NavBarSection = ({
       break;
     case "users":
       displayText = "Users";
+      break;
+    case "restriction-rules":
+      displayText = "Restriction Rules";
       break;
   }
 
@@ -101,6 +105,7 @@ const Layout: React.FC = () => {
             kind="authed-token"
           />
           <NavBarSection selected={navBarSection === "users"} kind="users" />
+          <NavBarSection selected={navBarSection === "restriction-rules"} kind="restriction-rules" />
         </nav>
       </div>
       <div className="w-full flex bg-gray-900 text-gray-300 sm:hidden">
@@ -166,12 +171,20 @@ const Layout: React.FC = () => {
                   Authed Token
                 </Link>
               </li>
-              <li className="pl-2 border-slate-400">
+              <li className="pl-2 border-b pb-1 border-slate-400 border-spacing-y-6">
                 <Link
                   to="/dashboard/users"
                   onClick={() => setIsNavbarOpen((x) => !x)}
                 >
                   Users
+                </Link>
+              </li>
+              <li className="pl-2 border-slate-400">
+                <Link
+                  to="/dashboard/restriction-rules"
+                  onClick={() => setIsNavbarOpen((x) => !x)}
+                >
+                  Restriction Rules
                 </Link>
               </li>
             </ul>

--- a/eddist-admin/openapi.json
+++ b/eddist-admin/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "info": {
     "title": "eddist-admin",
     "description": "",
@@ -168,7 +168,8 @@
             "description": "Board Key",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -259,8 +260,10 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "nullable": true
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
@@ -268,9 +271,11 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
-              "nullable": true,
               "minimum": 0
             }
           },
@@ -279,9 +284,11 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
-              "nullable": true,
               "minimum": 0
             }
           },
@@ -290,9 +297,11 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
-              "nullable": true,
               "minimum": 0
             }
           },
@@ -301,9 +310,11 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
-              "nullable": true,
               "minimum": 0
             }
           }
@@ -539,8 +550,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "default": null,
-                  "nullable": true
+                  "default": null
                 }
               }
             }
@@ -1081,6 +1091,145 @@
         }
       }
     },
+    "/restriction_rules": {
+      "get": {
+        "tags": [
+          "bbs"
+        ],
+        "operationId": "get_restriction_rules",
+        "responses": {
+          "200": {
+            "description": "List all restriction rules",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserRestrictionRuleSchema"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "bbs"
+        ],
+        "operationId": "create_restriction_rule",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRestrictionRuleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Create restriction rule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRestrictionRuleSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/restriction_rules/{rule_id}": {
+      "get": {
+        "tags": [
+          "bbs"
+        ],
+        "operationId": "get_restriction_rule",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "description": "Rule ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get restriction rule by ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRestrictionRuleSchema"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "bbs"
+        ],
+        "operationId": "delete_restriction_rule",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "description": "Rule ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delete restriction rule"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "bbs"
+        ],
+        "operationId": "update_restriction_rule",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "description": "Rule ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRestrictionRuleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Update restriction rule"
+          }
+        }
+      }
+    },
     "/users/search/": {
       "get": {
         "tags": [
@@ -1093,9 +1242,11 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
             }
           },
           {
@@ -1103,8 +1254,10 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "nullable": true
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
@@ -1112,9 +1265,11 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
             }
           }
         ],
@@ -1195,8 +1350,10 @@
             "type": "string"
           },
           "author_id": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "body": {
             "type": "string"
@@ -1245,8 +1402,10 @@
         ],
         "properties": {
           "author_id": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "body": {
             "type": "string"
@@ -1326,13 +1485,17 @@
         ],
         "properties": {
           "authed_at": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
           },
           "authed_ua": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -1343,9 +1506,11 @@
             "format": "uuid"
           },
           "last_wrote_at": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
           },
           "origin_ip": {
             "type": "string"
@@ -1442,12 +1607,16 @@
             "type": "boolean"
           },
           "threads_archive_cron": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "threads_archive_trigger_thread_count": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           }
         }
@@ -1507,12 +1676,14 @@
             "type": "string"
           },
           "tinker": {
-            "allOf": [
+            "oneOf": [
+              {
+                "type": "null"
+              },
               {
                 "$ref": "#/components/schemas/Tinker"
               }
-            ],
-            "nullable": true
+            ]
           },
           "user_agent": {
             "type": "string"
@@ -1529,13 +1700,17 @@
         ],
         "properties": {
           "base_response_creation_span_sec": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "base_thread_creation_span_sec": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "board_key": {
@@ -1548,41 +1723,81 @@
             "type": "string"
           },
           "max_author_name_byte_length": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "max_email_byte_length": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "max_response_body_byte_length": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "max_response_body_lines": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "max_thread_name_byte_length": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "name": {
             "type": "string"
           },
           "threads_archive_cron": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "threads_archive_trigger_thread_count": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
+          }
+        }
+      },
+      "CreateRestrictionRuleRequest": {
+        "type": "object",
+        "required": [
+          "name",
+          "rule_type",
+          "rule_value"
+        ],
+        "properties": {
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "rule_type": {
+            "type": "string"
+          },
+          "rule_value": {
+            "type": "string"
           }
         }
       },
@@ -1624,63 +1839,89 @@
         "type": "object",
         "properties": {
           "base_response_creation_span_sec": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "base_thread_creation_span_sec": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "default_name": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "local_rule": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "max_author_name_byte_length": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "max_email_byte_length": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "max_response_body_byte_length": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "max_response_body_lines": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "max_thread_name_byte_length": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "name": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "read_only": {
-            "type": "boolean",
-            "nullable": true
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "threads_archive_cron": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "threads_archive_trigger_thread_count": {
-            "type": "integer",
-            "nullable": true,
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           }
         }
@@ -1747,8 +1988,10 @@
             "type": "string"
           },
           "author_name": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "board_id": {
             "type": "string",
@@ -1775,8 +2018,10 @@
             "type": "boolean"
           },
           "mail": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "res_order": {
             "type": "integer",
@@ -1787,6 +2032,15 @@
             "format": "uuid"
           }
         }
+      },
+      "RestrictionRuleTypeSchema": {
+        "type": "string",
+        "enum": [
+          "ASN",
+          "IP",
+          "IPCidr",
+          "UserAgent"
+        ]
       },
       "Thread": {
         "type": "object",
@@ -1885,9 +2139,11 @@
             "minimum": 0
           },
           "last_created_thread_at": {
-            "type": "integer",
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int64",
-            "nullable": true,
             "minimum": 0
           },
           "last_level_up_at": {
@@ -1916,24 +2172,32 @@
         "type": "object",
         "properties": {
           "board_ids": {
-            "type": "array",
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "string",
               "format": "uuid"
-            },
-            "nullable": true
+            }
           },
           "description": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "name": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "password": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1941,20 +2205,26 @@
         "type": "object",
         "properties": {
           "board_ids": {
-            "type": "array",
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "string",
               "format": "uuid"
-            },
-            "nullable": true
+            }
           },
           "name": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "word": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1962,20 +2232,58 @@
         "type": "object",
         "properties": {
           "author_name": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "body": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "is_abone": {
-            "type": "boolean",
-            "nullable": true
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "mail": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "UpdateRestrictionRuleRequest": {
+        "type": "object",
+        "properties": {
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rule_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rule_value": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -2036,6 +2344,50 @@
           "user_id": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "UserRestrictionRuleSchema": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "rule_type",
+          "rule_value",
+          "created_at",
+          "updated_at",
+          "created_by_email"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by_email": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "rule_type": {
+            "$ref": "#/components/schemas/RestrictionRuleTypeSchema"
+          },
+          "rule_value": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },

--- a/eddist-admin/src/auth.rs
+++ b/eddist-admin/src/auth.rs
@@ -264,6 +264,10 @@ impl AdminSession {
             userinfo: None,
         }
     }
+
+    pub fn get_admin_email(&self) -> Option<String> {
+        self.userinfo.as_ref().map(|info| info.email.clone())
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/eddist-admin/src/repository/user_restriction_repository.rs
+++ b/eddist-admin/src/repository/user_restriction_repository.rs
@@ -1,0 +1,193 @@
+use async_trait::async_trait;
+use eddist_core::domain::user_restriction::{
+    CreateUserRestrictionRuleInput, RestrictionRuleType, UpdateUserRestrictionRuleInput,
+    UserRestrictionRule,
+};
+use sqlx::{MySql, Pool};
+use uuid::Uuid;
+
+#[async_trait]
+pub trait UserRestrictionRepository: Send + Sync {
+    async fn get_all_rules(&self) -> anyhow::Result<Vec<UserRestrictionRule>>;
+    async fn create_rule(
+        &self,
+        input: CreateUserRestrictionRuleInput,
+    ) -> anyhow::Result<UserRestrictionRule>;
+    async fn update_rule(&self, input: UpdateUserRestrictionRuleInput) -> anyhow::Result<()>;
+    async fn delete_rule(&self, id: Uuid) -> anyhow::Result<()>;
+    async fn get_rule_by_id(&self, id: Uuid) -> anyhow::Result<Option<UserRestrictionRule>>;
+}
+
+#[derive(Clone)]
+pub struct UserRestrictionRepositoryImpl {
+    pool: Pool<MySql>,
+}
+
+impl UserRestrictionRepositoryImpl {
+    pub fn new(pool: Pool<MySql>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl UserRestrictionRepository for UserRestrictionRepositoryImpl {
+    async fn get_all_rules(&self) -> anyhow::Result<Vec<UserRestrictionRule>> {
+        let rows = sqlx::query!(
+            r#"
+            SELECT 
+                BIN_TO_UUID(id) as id,
+                name,
+                rule_type,
+                rule_value,
+                expires_at,
+                created_at,
+                updated_at,
+                created_by_email
+            FROM user_restriction_rules
+            ORDER BY created_at DESC
+            "#
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut rules = Vec::new();
+        for row in rows {
+            if let Some(id) = row.id {
+                let rule_type = row
+                    .rule_type
+                    .parse::<RestrictionRuleType>()
+                    .map_err(|e| anyhow::anyhow!("Invalid rule type '{}': {}", row.rule_type, e))?;
+
+                rules.push(UserRestrictionRule {
+                    id: Uuid::parse_str(&id)?,
+                    name: row.name,
+                    rule_type,
+                    rule_value: row.rule_value,
+                    expires_at: row.expires_at.map(|dt| dt.and_utc()),
+                    created_at: row.created_at.and_utc(),
+                    updated_at: row.updated_at.and_utc(),
+                    created_by_email: row.created_by_email,
+                });
+            }
+        }
+
+        Ok(rules)
+    }
+
+    async fn create_rule(
+        &self,
+        input: CreateUserRestrictionRuleInput,
+    ) -> anyhow::Result<UserRestrictionRule> {
+        let id = Uuid::new_v4();
+        let now = chrono::Utc::now().naive_utc();
+
+        sqlx::query!(
+            r#"
+            INSERT INTO user_restriction_rules 
+            (id, name, rule_type, rule_value, expires_at, created_at, updated_at, created_by_email)
+            VALUES (UUID_TO_BIN(?), ?, ?, ?, ?, ?, ?, ?)
+            "#,
+            id.to_string(),
+            input.name,
+            input.rule_type.as_str(),
+            input.rule_value,
+            input.expires_at.map(|dt| dt.naive_utc()),
+            now,
+            now,
+            input.created_by_email
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(UserRestrictionRule {
+            id,
+            name: input.name,
+            rule_type: input.rule_type,
+            rule_value: input.rule_value,
+            expires_at: input.expires_at,
+            created_at: now.and_utc(),
+            updated_at: now.and_utc(),
+            created_by_email: input.created_by_email,
+        })
+    }
+
+    async fn update_rule(&self, input: UpdateUserRestrictionRuleInput) -> anyhow::Result<()> {
+        let now = chrono::Utc::now().naive_utc();
+
+        if let (Some(name), Some(rule_type), Some(rule_value)) =
+            (&input.name, &input.rule_type, &input.rule_value)
+        {
+            sqlx::query!(
+                r#"
+                UPDATE user_restriction_rules 
+                SET name = ?, rule_type = ?, rule_value = ?, expires_at = ?, updated_at = ?
+                WHERE id = UUID_TO_BIN(?)
+                "#,
+                name,
+                rule_type.as_str(),
+                rule_value,
+                input.expires_at.flatten().map(|dt| dt.naive_utc()),
+                now,
+                input.id.to_string()
+            )
+            .execute(&self.pool)
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn delete_rule(&self, id: Uuid) -> anyhow::Result<()> {
+        sqlx::query!(
+            "DELETE FROM user_restriction_rules WHERE id = UUID_TO_BIN(?)",
+            id.to_string()
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn get_rule_by_id(&self, id: Uuid) -> anyhow::Result<Option<UserRestrictionRule>> {
+        let row = sqlx::query!(
+            r#"
+            SELECT 
+                BIN_TO_UUID(id) as id,
+                name,
+                rule_type,
+                rule_value,
+                expires_at,
+                created_at,
+                updated_at,
+                created_by_email
+            FROM user_restriction_rules
+            WHERE id = UUID_TO_BIN(?)
+            "#,
+            id.to_string()
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if let Some(row) = row {
+            if let Some(id_str) = row.id {
+                let rule_type = row
+                    .rule_type
+                    .parse::<RestrictionRuleType>()
+                    .map_err(|e| anyhow::anyhow!("Invalid rule type '{}': {}", row.rule_type, e))?;
+
+                return Ok(Some(UserRestrictionRule {
+                    id: Uuid::parse_str(&id_str)?,
+                    name: row.name,
+                    rule_type,
+                    rule_value: row.rule_value,
+                    expires_at: row.expires_at.map(|dt| dt.and_utc()),
+                    created_at: row.created_at.and_utc(),
+                    updated_at: row.updated_at.and_utc(),
+                    created_by_email: row.created_by_email,
+                }));
+            }
+        }
+
+        Ok(None)
+    }
+}

--- a/eddist-core/Cargo.toml
+++ b/eddist-core/Cargo.toml
@@ -16,3 +16,4 @@ sha3 = "0.10.8"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 metrics = "0.24.2"
+ipnet = "2.9"

--- a/eddist-core/src/domain/user_restriction.rs
+++ b/eddist-core/src/domain/user_restriction.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::net::IpAddr;
+use std::str::FromStr;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum RestrictionRuleType {
+    ASN,
+    IP,
+    IPCidr,
+    UserAgent,
+}
+
+impl RestrictionRuleType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RestrictionRuleType::ASN => "ASN",
+            RestrictionRuleType::IP => "IP",
+            RestrictionRuleType::IPCidr => "IP_CIDR",
+            RestrictionRuleType::UserAgent => "USER_AGENT",
+        }
+    }
+}
+
+impl FromStr for RestrictionRuleType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASN" => Ok(RestrictionRuleType::ASN),
+            "IP" => Ok(RestrictionRuleType::IP),
+            "IP_CIDR" => Ok(RestrictionRuleType::IPCidr),
+            "USER_AGENT" => Ok(RestrictionRuleType::UserAgent),
+            _ => Err(format!("Invalid restriction rule type: {}", s)),
+        }
+    }
+}
+
+impl Display for RestrictionRuleType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserRestrictionRule {
+    pub id: Uuid,
+    pub name: String,
+    pub rule_type: RestrictionRuleType,
+    pub rule_value: String,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub created_by_email: String,
+}
+
+impl UserRestrictionRule {
+    pub fn is_expired(&self) -> bool {
+        if let Some(expires_at) = self.expires_at {
+            chrono::Utc::now() > expires_at
+        } else {
+            false
+        }
+    }
+
+    pub fn matches(&self, ip: &str, asn: u32, user_agent: &str) -> bool {
+        if self.is_expired() {
+            return false;
+        }
+
+        match self.rule_type {
+            RestrictionRuleType::ASN => {
+                if let Ok(rule_asn) = self.rule_value.parse::<u32>() {
+                    rule_asn == asn
+                } else {
+                    false
+                }
+            }
+            RestrictionRuleType::IP => self.rule_value == ip,
+            RestrictionRuleType::IPCidr => {
+                if let Ok(ip_addr) = ip.parse::<IpAddr>() {
+                    if let Ok(cidr) = self.rule_value.parse::<ipnet::IpNet>() {
+                        cidr.contains(&ip_addr)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            RestrictionRuleType::UserAgent => {
+                self.rule_value == user_agent || user_agent.contains(&self.rule_value)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateUserRestrictionRuleInput {
+    pub name: String,
+    pub rule_type: RestrictionRuleType,
+    pub rule_value: String,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub created_by_email: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateUserRestrictionRuleInput {
+    pub id: Uuid,
+    pub name: Option<String>,
+    pub rule_type: Option<RestrictionRuleType>,
+    pub rule_value: Option<String>,
+    pub expires_at: Option<Option<chrono::DateTime<chrono::Utc>>>,
+}

--- a/eddist-core/src/lib.rs
+++ b/eddist-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod domain {
     pub mod res;
     pub mod sjis_str;
     pub mod tinker;
+    pub mod user_restriction;
 }
 
 pub mod cache_aside;

--- a/eddist-server/src/domain/service/ng_word_reading_service.rs
+++ b/eddist-server/src/domain/service/ng_word_reading_service.rs
@@ -1,4 +1,4 @@
-use eddist_core::cache_aside::{AsCache, ToCache, cache_aside};
+use eddist_core::cache_aside::{cache_aside, AsCache, ToCache};
 use redis::aio::ConnectionManager;
 use serde::{Deserialize, Serialize};
 

--- a/eddist-server/src/domain/service/oidc_client_service.rs
+++ b/eddist-server/src/domain/service/oidc_client_service.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use base64::Engine;
-use chacha20poly1305::{KeyInit, aead::Aead};
+use chacha20poly1305::{aead::Aead, KeyInit};
 use eddist_core::cache_aside::{self, AsCache, ToCache};
-use openidconnect::{ClientId, ClientSecret, core::CoreProviderMetadata};
+use openidconnect::{core::CoreProviderMetadata, ClientId, ClientSecret};
 use redis::aio::ConnectionManager;
 use serde::{Deserialize, Serialize};
 

--- a/eddist-server/src/domain/service/res_creation_span_management_service.rs
+++ b/eddist-server/src/domain/service/res_creation_span_management_service.rs
@@ -1,4 +1,4 @@
-use redis::{AsyncCommands, aio::ConnectionManager};
+use redis::{aio::ConnectionManager, AsyncCommands};
 
 use crate::utils::redis::{
     res_creation_span_ip_key, res_creation_span_key, thread_creation_span_ip_key,

--- a/eddist-server/src/error.rs
+++ b/eddist-server/src/error.rs
@@ -55,7 +55,9 @@ pub enum BbsCgiError {
     #[error("{0}が空です")]
     ContentEmpty(ContentEmptyParamType),
 
-    #[error("短期間に書き込みすぎです (Lv{tinker_level}は{span_sec}秒以内に1回書き込むことができます)")]
+    #[error(
+        "短期間に書き込みすぎです (Lv{tinker_level}は{span_sec}秒以内に1回書き込むことができます)"
+    )]
     TooManyCreatingRes { tinker_level: u32, span_sec: i32 },
 
     #[error(

--- a/eddist-server/src/external/oidc_client.rs
+++ b/eddist-server/src/external/oidc_client.rs
@@ -1,13 +1,13 @@
 use std::env;
 
 use openidconnect::{
-    AuthenticationFlow, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
-    EmptyAdditionalClaims, IdTokenClaims, Nonce, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl,
-    TokenResponse,
     core::{
         CoreClient, CoreGenderClaim, CoreJwsSigningAlgorithm, CoreProviderMetadata,
         CoreResponseType,
     },
+    AuthenticationFlow, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
+    EmptyAdditionalClaims, IdTokenClaims, Nonce, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl,
+    TokenResponse,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/eddist-server/src/middleware/mod.rs
+++ b/eddist-server/src/middleware/mod.rs
@@ -1,0 +1,1 @@
+pub mod user_restriction;

--- a/eddist-server/src/middleware/user_restriction.rs
+++ b/eddist-server/src/middleware/user_restriction.rs
@@ -1,0 +1,64 @@
+use axum::{
+    extract::{Request, State},
+    http::{Method, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use eddist_core::domain::user_restriction::UserRestrictionRule;
+
+use crate::{
+    services::{
+        user_restriction_service::{UserRestrictionCheckInput, UserRestrictionCheckOutput},
+        AppService,
+    },
+    utils::{get_asn_num, get_origin_ip, get_ua},
+    AppState,
+};
+
+pub async fn user_restriction_middleware(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    // Check if this is a route we want to restrict
+    let path = request.uri().path();
+    let should_check = path.starts_with("/test/bbs.cgi")
+        || (path.starts_with("/auth-code") && request.method() == Method::POST);
+
+    if !should_check {
+        return next.run(request).await;
+    }
+
+    let headers = request.headers();
+    let ip = get_origin_ip(headers);
+    let asn = get_asn_num(headers);
+    let ua = get_ua(headers);
+
+    let restriction_service = state.get_container().user_restriction();
+
+    let check_input = UserRestrictionCheckInput {
+        ip: ip.to_string(),
+        asn,
+        user_agent: ua.to_string(),
+    };
+
+    match restriction_service.execute(check_input).await {
+        Ok(UserRestrictionCheckOutput { matching_rule }) => {
+            if let Some(UserRestrictionRule {
+                name,
+                rule_type,
+                rule_value,
+                ..
+            }) = matching_rule
+            {
+                tracing::warn!(
+                    "Request blocked by user restriction filter: IP={ip}, ASN={asn}, UA={ua}, path={path}; rule={name}, {rule_type}, {rule_value}"
+                );
+                return (StatusCode::FORBIDDEN, "Access denied").into_response();
+            }
+        }
+        Err(e) => tracing::error!("Error checking user restrictions: {}", e),
+    }
+
+    next.run(request).await
+}

--- a/eddist-server/src/repositories/bbs_pubsub_repository.rs
+++ b/eddist-server/src/repositories/bbs_pubsub_repository.rs
@@ -1,5 +1,5 @@
 use eddist_core::domain::pubsub_repository::PubSubItem;
-use redis::{AsyncCommands, aio::ConnectionManager};
+use redis::{aio::ConnectionManager, AsyncCommands};
 
 #[derive(Clone)]
 pub struct RedisPubRepository {

--- a/eddist-server/src/repositories/bbs_repository.rs
+++ b/eddist-server/src/repositories/bbs_repository.rs
@@ -775,10 +775,7 @@ impl BbsRepository for BbsRepositoryImpl {
     }
 
     async fn delete_authed_token(&self, token: &str) -> anyhow::Result<()> {
-        let query = query!(
-            "DELETE FROM authed_tokens WHERE token = ?",
-            token
-        );
+        let query = query!("DELETE FROM authed_tokens WHERE token = ?", token);
 
         query.execute(&self.pool).await?;
 

--- a/eddist-server/src/repositories/user_restriction_repository.rs
+++ b/eddist-server/src/repositories/user_restriction_repository.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+use eddist_core::domain::user_restriction::{RestrictionRuleType, UserRestrictionRule};
+use sqlx::{MySql, Pool};
+use uuid::Uuid;
+
+#[async_trait]
+pub trait UserRestrictionRepository: Send + Sync {
+    async fn get_all_active_rules(&self) -> anyhow::Result<Vec<UserRestrictionRule>>;
+}
+
+#[derive(Clone)]
+pub struct UserRestrictionRepositoryImpl {
+    pool: Pool<MySql>,
+}
+
+impl UserRestrictionRepositoryImpl {
+    pub fn new(pool: Pool<MySql>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl UserRestrictionRepository for UserRestrictionRepositoryImpl {
+    async fn get_all_active_rules(&self) -> anyhow::Result<Vec<UserRestrictionRule>> {
+        let rows = sqlx::query!(
+            r#"
+            SELECT 
+                BIN_TO_UUID(id) as id,
+                name,
+                rule_type,
+                rule_value,
+                expires_at,
+                created_at,
+                updated_at,
+                created_by_email
+            FROM user_restriction_rules
+            WHERE expires_at IS NULL OR expires_at > NOW()
+            ORDER BY created_at DESC
+            "#
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut rules = Vec::with_capacity(rows.len());
+        for row in rows {
+            if let Some(id) = row.id {
+                let rule_type = row
+                    .rule_type
+                    .parse::<RestrictionRuleType>()
+                    .map_err(|e| anyhow::anyhow!("Invalid rule type '{}': {}", row.rule_type, e))?;
+
+                rules.push(UserRestrictionRule {
+                    id: Uuid::parse_str(&id)?,
+                    name: row.name,
+                    rule_type,
+                    rule_value: row.rule_value,
+                    expires_at: row.expires_at.map(|dt| dt.and_utc()),
+                    created_at: row.created_at.and_utc(),
+                    updated_at: row.updated_at.and_utc(),
+                    created_by_email: row.created_by_email,
+                });
+            }
+        }
+
+        Ok(rules)
+    }
+}

--- a/eddist-server/src/routes/auth_code.rs
+++ b/eddist-server/src/routes/auth_code.rs
@@ -1,22 +1,22 @@
 use std::collections::HashMap;
 
 use axum::{
-    Form,
     extract::State,
     response::{Html, IntoResponse},
+    Form,
 };
 use http::HeaderMap;
 use serde_json::json;
 
 use crate::{
-    AppState,
     domain::captcha_like::CaptchaLikeConfig,
     error::BbsPostAuthWithCodeError,
     services::{
-        AppService,
         auth_with_code_service::{AuthWithCodeServiceInput, AuthWithCodeServiceOutput},
+        AppService,
     },
     utils::{get_origin_ip, get_ua},
+    AppState,
 };
 
 // NOTE: this system will be changed in the future

--- a/eddist-server/src/routes/dat_routing.rs
+++ b/eddist-server/src/routes/dat_routing.rs
@@ -10,12 +10,12 @@ use eddist_core::domain::{board::validate_board_key, sjis_str::SJisStr};
 use http::{HeaderMap, StatusCode};
 
 use crate::{
-    AppState,
     services::{
-        AppService, kako_thread_retrieval_service::KakoThreadRetrievalServiceInput,
-        thread_retrieval_service::ThreadRetrievalServiceInput,
+        kako_thread_retrieval_service::KakoThreadRetrievalServiceInput,
+        thread_retrieval_service::ThreadRetrievalServiceInput, AppService,
     },
     shiftjis::{SJisResponseBuilder, SjisContentType},
+    AppState,
 };
 
 pub async fn get_dat_txt(

--- a/eddist-server/src/routes/subject_list.rs
+++ b/eddist-server/src/routes/subject_list.rs
@@ -6,9 +6,9 @@ use axum::{
 use eddist_core::domain::{board::validate_board_key, sjis_str::SJisStr};
 
 use crate::{
-    AppState,
-    services::{AppService, thread_list_service::BoardKey},
+    services::{thread_list_service::BoardKey, AppService},
     shiftjis::{SJisResponseBuilder, SjisContentType},
+    AppState,
 };
 
 pub async fn get_subject_txt(

--- a/eddist-server/src/services/auth_with_code_service.rs
+++ b/eddist-server/src/services/auth_with_code_service.rs
@@ -128,14 +128,15 @@ impl<T: BbsRepository> AppService<AuthWithCodeServiceInput, AuthWithCodeServiceO
         }
 
         // Check IP equality for users not using spur.us (Monocle already handles IPv4/IPv6 checking)
-        let has_monocle = input.captcha_like_configs.iter().any(|config| {
-            matches!(config, CaptchaLikeConfig::Monocle { .. })
-        });
-        
+        let has_monocle = input
+            .captcha_like_configs
+            .iter()
+            .any(|config| matches!(config, CaptchaLikeConfig::Monocle { .. }));
+
         if !has_monocle {
-            let token_origin_ip = ReducedIpAddr::from(token.reduced_ip.clone());
+            let token_origin_ip = token.reduced_ip.clone();
             let request_origin_ip = ReducedIpAddr::from(input.origin_ip.clone());
-            
+
             if token_origin_ip != request_origin_ip {
                 counter!("issue_authed_token", "state" => "failed", "reason" => "ip_mismatch")
                     .increment(1);

--- a/eddist-server/src/services/auth_with_code_user_page_service.rs
+++ b/eddist-server/src/services/auth_with_code_user_page_service.rs
@@ -1,11 +1,11 @@
 use chrono::Utc;
 use metrics::counter;
-use redis::{AsyncCommands, aio::ConnectionManager};
+use redis::{aio::ConnectionManager, AsyncCommands};
 use sqlx::MySql;
 
 use crate::{
     repositories::{bbs_repository::BbsRepository, user_repository::UserRepository},
-    utils::{TransactionRepository, redis::user_session_key},
+    utils::{redis::user_session_key, TransactionRepository},
 };
 
 use super::AppService;

--- a/eddist-server/src/services/user_restriction_service.rs
+++ b/eddist-server/src/services/user_restriction_service.rs
@@ -1,0 +1,129 @@
+use std::{
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant},
+};
+
+use eddist_core::domain::user_restriction::UserRestrictionRule;
+use tokio::sync::RwLock;
+
+use crate::repositories::user_restriction_repository::UserRestrictionRepository;
+
+use super::AppService;
+
+static GLOBAL_RESTRICTION_CACHE: OnceLock<Arc<RwLock<RestrictionCache>>> = OnceLock::new();
+
+fn get_global_cache() -> &'static Arc<RwLock<RestrictionCache>> {
+    GLOBAL_RESTRICTION_CACHE.get_or_init(|| Arc::new(RwLock::new(RestrictionCache::new())))
+}
+
+#[derive(Debug, Clone)]
+pub struct UserRestrictionService<T: UserRestrictionRepository> {
+    repo: T,
+}
+
+#[derive(Debug)]
+struct RestrictionCache {
+    rules: Vec<UserRestrictionRule>,
+    last_updated: Instant,
+}
+
+impl RestrictionCache {
+    fn new() -> Self {
+        Self {
+            rules: Vec::new(),
+            last_updated: Instant::now(),
+        }
+    }
+
+    fn update_rules(&mut self, rules: Vec<UserRestrictionRule>) {
+        self.rules = rules;
+        self.last_updated = Instant::now();
+    }
+}
+
+impl<T: UserRestrictionRepository + Clone> UserRestrictionService<T> {
+    pub fn new(repo: T) -> Self {
+        Self { repo }
+    }
+
+    /// Refresh the cache immediately, typically called by background tasks
+    pub async fn refresh_cache(&self) -> anyhow::Result<()> {
+        let rules = self.repo.get_all_active_rules().await?;
+        let global_cache = get_global_cache();
+        let mut cache = global_cache.write().await;
+        cache.update_rules(rules);
+        tracing::info!(
+            "User restriction cache refreshed with {} rules",
+            cache.rules.len()
+        );
+        Ok(())
+    }
+
+    pub async fn is_restricted(
+        &self,
+        ip: &str,
+        asn: u32,
+        user_agent: &str,
+    ) -> anyhow::Result<Option<UserRestrictionRule>> {
+        let global_cache = get_global_cache();
+        let cache = global_cache.read().await;
+        for rule in &cache.rules {
+            if rule.matches(ip, asn, user_agent) {
+                return Ok(Some(rule.clone()));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: UserRestrictionRepository + Clone>
+    AppService<UserRestrictionCheckInput, UserRestrictionCheckOutput>
+    for UserRestrictionService<T>
+{
+    async fn execute(
+        &self,
+        input: UserRestrictionCheckInput,
+    ) -> anyhow::Result<UserRestrictionCheckOutput> {
+        let matching_rule = self
+            .is_restricted(&input.ip, input.asn, &input.user_agent)
+            .await?;
+
+        Ok(UserRestrictionCheckOutput { matching_rule })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UserRestrictionCheckInput {
+    pub ip: String,
+    pub asn: u32,
+    pub user_agent: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UserRestrictionCheckOutput {
+    pub matching_rule: Option<UserRestrictionRule>,
+}
+
+/// Start a background task that periodically refreshes the user restriction cache
+pub fn start_cache_refresh_task<T: UserRestrictionRepository + Clone + Send + Sync + 'static>(
+    repo: T,
+    refresh_interval: Duration,
+) {
+    tokio::spawn(async move {
+        let service = UserRestrictionService::new(repo);
+        let mut interval = tokio::time::interval(refresh_interval);
+
+        loop {
+            interval.tick().await;
+            if let Err(e) = service.refresh_cache().await {
+                tracing::error!("Failed to refresh user restriction cache: {e}");
+            }
+        }
+    });
+
+    tracing::info!(
+        "Started user restriction cache refresh task with interval: {refresh_interval:?}",
+    );
+}

--- a/eddist-server/src/shiftjis.rs
+++ b/eddist-server/src/shiftjis.rs
@@ -4,7 +4,7 @@ use axum::{
     http::{HeaderName, HeaderValue},
     response::{IntoResponse, Response},
 };
-use axum_extra::extract::{CookieJar, cookie::Cookie};
+use axum_extra::extract::{cookie::Cookie, CookieJar};
 use eddist_core::domain::sjis_str::SJisStr;
 use hyper::StatusCode;
 

--- a/migrations/20250720034037_user_restriction_rules.down.sql
+++ b/migrations/20250720034037_user_restriction_rules.down.sql
@@ -1,0 +1,2 @@
+-- Drop user_restriction_rules table
+DROP TABLE user_restriction_rules;

--- a/migrations/20250720034037_user_restriction_rules.up.sql
+++ b/migrations/20250720034037_user_restriction_rules.up.sql
@@ -1,0 +1,14 @@
+-- Create user_restriction_rules table
+CREATE TABLE user_restriction_rules (
+    id BINARY(16) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    rule_type ENUM('ASN', 'IP', 'IP_CIDR', 'USER_AGENT') NOT NULL,
+    rule_value TEXT NOT NULL,
+    expires_at DATETIME(3),
+    created_at DATETIME(3) NOT NULL,
+    updated_at DATETIME(3) NOT NULL,
+    created_by_email VARCHAR(255) NOT NULL,
+    INDEX (rule_type),
+    INDEX (expires_at),
+    INDEX (created_at)
+);


### PR DESCRIPTION
## Abstract
- Added user restriction rules repository and service for managing user access based on IP, ASN, and User-Agent.
- Created middleware to enforce user restrictions on specific routes.
- Introduced a background task to refresh the user restriction cache periodically.
- Developed frontend components for creating, editing, and deleting restriction rules in the admin dashboard.
- Added database migration scripts for the user_restriction_rules table.