### PR TITLE
feat: enable gzip compression with fastest level for BBS endpoints

### DIFF
--- a/eddist-server/src/app.rs
+++ b/eddist-server/src/app.rs
@@ -297,8 +297,8 @@ pub fn create_app(app_state: AppState, conn_mgr: redis::aio::ConnectionManager) 
         ))
         .layer(
             CompressionLayer::new()
-                .gzip(true)
-                .br(false)
+                .gzip(false)
+                .br(true)
                 .quality(tower_http::CompressionLevel::Fastest),
         )
         .layer(


### PR DESCRIPTION
Enable tower-http CompressionLayer with gzip level 1 (fastest) to reduce
transfer size for subject.txt, subject-metadent.txt, and .dat responses.
Brotli disabled as BBS clients do not use it. Range requests are unaffected
since tower-http skips compression when a Range header is present.