### PR TITLE
test: set TIME_TRUNCATE_FRACTIONAL on test pool to fix flaky dat parity test

### DIFF
--- a/eddist-server/tests/common/mod.rs
+++ b/eddist-server/tests/common/mod.rs
@@ -38,6 +38,17 @@ impl TestContext {
         let database_url = format!("mysql://root@127.0.0.1:{mysql_port}/test");
 
         let pool = MySqlPoolOptions::new()
+            .after_connect(|conn, _| {
+                use sqlx::Executor;
+                Box::pin(async move {
+                    conn.execute(
+                        "SET SESSION sql_mode = CONCAT(@@sql_mode, ',TIME_TRUNCATE_FRACTIONAL')",
+                    )
+                    .await
+                    .unwrap();
+                    Ok(())
+                })
+            })
             .max_connections(5)
             .acquire_timeout(Duration::from_secs(10))
             .connect(&database_url)


### PR DESCRIPTION
MySQL DATETIME(3) rounds sub-millisecond values by default, but chrono's %3f format truncates. This divergence caused test_dat_cache_and_db_parity to intermittently fail when created_at had >=500µs past a ms boundary. Matches the same after_connect hook already set in main.rs.