### PR TITLE
feat: add layer3intel_tripwire captcha provider with local JWE decryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ node_modules/
 .cursor/
 CLAUDE.md
 .serena/
+
+tmp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher 0.4.4",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1017,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1297,7 @@ dependencies = [
 name = "eddist"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-trait",
  "axum",
@@ -1290,6 +1325,7 @@ dependencies = [
  "mimalloc",
  "mockall",
  "openidconnect",
+ "p256",
  "pwhash",
  "rand 0.10.0",
  "redis",
@@ -1856,6 +1892,16 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -3247,6 +3293,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ sha1 = { version = "0.10.6", default-features = false }
 md-5 = "0.10.6"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 chacha20poly1305 = "0.10.1"
-p256    = { version = "0.13", features = ["ecdh", "pkcs8", "pem"] }
+p256 = { version = "0.13", features = ["ecdh", "pkcs8", "pem"] }
 aes-gcm = "0.10"
 pwhash = "1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,8 @@ sha1 = { version = "0.10.6", default-features = false }
 md-5 = "0.10.6"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 chacha20poly1305 = "0.10.1"
+p256    = { version = "0.13", features = ["ecdh", "pkcs8", "pem"] }
+aes-gcm = "0.10"
 pwhash = "1.0.0"
 
 # Cloud storage

--- a/captcha-config.example.json
+++ b/captcha-config.example.json
@@ -65,5 +65,18 @@
             "success_path": "success",
             "include_ip": false
         }
+    },
+    {
+        "name": "layer3intel_tripwire",
+        "provider": "layer3intel_tripwire",
+        "site_key": "YOUR_TRIPWIRE_SITE_KEY",
+        "secret": "-----BEGIN PRIVATE KEY-----\nYOUR_PKCS8_EC_P256_PRIVATE_KEY\n-----END PRIVATE KEY-----",
+        "capture_fields": ["proxy", "proxy_type", "source_ip", "uuid"],
+        "widget": {
+            "form_field_name": "tripwire_token",
+            "script_url": "https://cdn.layer3intel.com/tripwire.min.js?key={{site_key}}",
+            "widget_html": "",
+            "script_handler": "(function() {\n  var form = document.getElementById('login-form');\n  form.addEventListener('submit', function(e) {\n    if (document.querySelector('input[name=\"tripwire_token\"]')) return;\n    if (typeof window.Tripwire === 'undefined') return;\n    e.preventDefault();\n    var self = this;\n    window.Tripwire.run().then(function(result) {\n      var input = document.createElement('input');\n      input.type = 'hidden';\n      input.name = 'tripwire_token';\n      input.value = result.token;\n      self.appendChild(input);\n      self.submit();\n    }).catch(function() { self.submit(); });\n  });\n})();"
+        }
     }
 ]

--- a/eddist-admin/client/app/components/CaptchaConfigForm.tsx
+++ b/eddist-admin/client/app/components/CaptchaConfigForm.tsx
@@ -9,8 +9,15 @@ type CreateCaptchaConfigInput =
 type UpdateCaptchaConfigInput =
   paths["/captcha-configs/{id}/"]["patch"]["requestBody"]["content"]["application/json"];
 
-const KNOWN_PROVIDERS = ["turnstile", "hcaptcha", "monocle", "recaptcha_enterprise", "custom"];
-const FIRST_CLASS_PROVIDERS = ["turnstile", "hcaptcha", "monocle"];
+const KNOWN_PROVIDERS = [
+  "turnstile",
+  "hcaptcha",
+  "monocle",
+  "layer3intel_tripwire",
+  "recaptcha_enterprise",
+  "custom",
+];
+const FIRST_CLASS_PROVIDERS = ["turnstile", "hcaptcha", "monocle", "layer3intel_tripwire"];
 
 type Props =
   | {

--- a/eddist-admin/client/app/routes/dashboard.captcha-configs.tsx
+++ b/eddist-admin/client/app/routes/dashboard.captcha-configs.tsx
@@ -48,6 +48,8 @@ const CaptchaConfigs = () => {
         return "info";
       case "monocle":
         return "purple";
+      case "layer3intel_tripwire":
+        return "green";
       default:
         return "gray";
     }

--- a/eddist-core/src/redis_keys.rs
+++ b/eddist-core/src/redis_keys.rs
@@ -58,6 +58,10 @@ pub fn authed_token_suspended_key(authed_token_id: &str) -> String {
     format!("authed_token:suspended:{authed_token_id}")
 }
 
+pub fn tripwire_uuid_seen_key(uuid: &str) -> String {
+    format!("captcha:tripwire:uuid:{uuid}")
+}
+
 pub const DB_FAILED_CACHE_RES_KEY: &str = "bbs:db_failed_cache:res";
 
 pub const CHANNEL_RES_CREATED: &str = "bbs:event:res_created";

--- a/eddist-server/Cargo.toml
+++ b/eddist-server/Cargo.toml
@@ -63,6 +63,8 @@ tower.workspace = true
 openidconnect.workspace = true
 url.workspace = true
 chacha20poly1305.workspace = true
+p256.workspace = true
+aes-gcm.workspace = true
 toml.workspace = true
 mimalloc = { workspace = true }
 

--- a/eddist-server/src/domain/captcha_like.rs
+++ b/eddist-server/src/domain/captcha_like.rs
@@ -94,6 +94,16 @@ pub struct MonocleResponse {
     pub sid: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TripwireAssessment {
+    pub proxy: Option<bool>,
+    pub proxy_type: Option<String>,
+    pub timestamp: Option<i64>,
+    pub source_ip: Option<String>,
+    pub key: Option<String>,
+    pub uuid: Option<String>,
+}
+
 /// Configuration for a captcha provider
 #[derive(Clone, Serialize, Deserialize)]
 pub struct CaptchaProviderConfig {

--- a/eddist-server/src/external/captcha_like_client.rs
+++ b/eddist-server/src/external/captcha_like_client.rs
@@ -1,15 +1,25 @@
 use std::collections::HashMap;
 
+use aes_gcm::{
+    Aes256Gcm, KeyInit,
+    aead::{Aead, Payload},
+};
+use base64::Engine;
 use eddist_core::{domain::ip_addr::ReducedIpAddr, utils::is_prod};
 use jsonpath_rust::JsonPath;
+use p256::{
+    PublicKey as P256PublicKey, SecretKey as P256SecretKey, ecdh::diffie_hellman,
+    pkcs8::DecodePrivateKey,
+};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::domain::{
     captcha_like::{
         CaptchaProviderConfig, CaptchaVerificationConfig, GRECAPTCHA_ENTERPRISE_DEFAULT_ACTION,
         GRECAPTCHA_ENTERPRISE_URL, GrecaptchaEnterpriseRequest, GrecaptchaEnterpriseResponse,
         HCAPTCHA_URL, HCaptchaResponse, HttpMethod, MONOCLE_URL, MonocleResponse,
-        PlaceholderResolver, RequestFormat, TURNSTILE_URL, TurnstileResponse,
+        PlaceholderResolver, RequestFormat, TURNSTILE_URL, TripwireAssessment, TurnstileResponse,
     },
     utils::SimpleSecret,
 };
@@ -31,6 +41,24 @@ pub struct CaptchaVerificationOutput {
     pub captured_data: Option<serde_json::Value>,
     /// Provider name for aggregation
     pub provider: String,
+}
+
+fn extract_fields(source: &impl Serialize, fields: &[String]) -> Option<serde_json::Value> {
+    if fields.is_empty() {
+        return None;
+    }
+    let json = serde_json::to_value(source).ok()?;
+    let mut captured = serde_json::Map::new();
+    for field in fields {
+        if let Some(value) = json.get(field) {
+            captured.insert(field.clone(), value.clone());
+        }
+    }
+    if captured.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(captured))
+    }
 }
 
 /// Factory function to create the appropriate captcha client based on provider config
@@ -62,6 +90,11 @@ pub fn create_captcha_client(config: &CaptchaProviderConfig) -> Box<dyn CaptchaC
                 .as_ref()
                 .and_then(|v| v.score_threshold)
                 .unwrap_or(0.5),
+            config.capture_fields.clone(),
+        )),
+        "layer3intel_tripwire" => Box::new(Layer3IntelTripwireClient::new(
+            name,
+            config.secret.clone(),
             config.capture_fields.clone(),
         )),
         // For other providers, use the generic client
@@ -159,25 +192,7 @@ impl HCaptchaClient {
     }
 
     fn extract_captured_data(&self, resp: &HCaptchaResponse) -> Option<serde_json::Value> {
-        if self.capture_fields.is_empty() {
-            return None;
-        }
-
-        // Convert HCaptchaResponse to JSON for field extraction
-        let resp_json = serde_json::to_value(resp).ok()?;
-
-        let mut captured = serde_json::Map::new();
-        for field in &self.capture_fields {
-            if let Some(value) = resp_json.get(field) {
-                captured.insert(field.clone(), value.clone());
-            }
-        }
-
-        if captured.is_empty() {
-            None
-        } else {
-            Some(serde_json::Value::Object(captured))
-        }
+        extract_fields(resp, &self.capture_fields)
     }
 }
 
@@ -244,25 +259,7 @@ impl MonocleClient {
     }
 
     fn extract_captured_data(&self, resp: &MonocleResponse) -> Option<serde_json::Value> {
-        if self.capture_fields.is_empty() {
-            return None;
-        }
-
-        // Convert MonocleResponse to JSON for field extraction
-        let resp_json = serde_json::to_value(resp).ok()?;
-
-        let mut captured = serde_json::Map::new();
-        for field in &self.capture_fields {
-            if let Some(value) = resp_json.get(field) {
-                captured.insert(field.clone(), value.clone());
-            }
-        }
-
-        if captured.is_empty() {
-            None
-        } else {
-            Some(serde_json::Value::Object(captured))
-        }
+        extract_fields(resp, &self.capture_fields)
     }
 }
 
@@ -338,6 +335,221 @@ impl CaptchaClient for MonocleClient {
 
         Ok(CaptchaVerificationOutput {
             result,
+            captured_data,
+            provider: self.name.clone(),
+        })
+    }
+}
+
+pub struct Layer3IntelTripwireClient {
+    name: String,
+    private_key_pem: SimpleSecret,
+    capture_fields: Vec<String>,
+}
+
+impl Layer3IntelTripwireClient {
+    pub fn new(name: String, private_key_pem: String, capture_fields: Vec<String>) -> Self {
+        Self {
+            name,
+            private_key_pem: SimpleSecret::new(&private_key_pem),
+            capture_fields,
+        }
+    }
+
+    fn extract_captured_data(&self, assessment: &TripwireAssessment) -> Option<serde_json::Value> {
+        extract_fields(assessment, &self.capture_fields)
+    }
+
+    /// Decrypt a JWE compact serialization (ECDH-ES + A256GCM) using the configured private key.
+    fn decrypt_jwe(&self, jwe: &str) -> Result<Vec<u8>, CaptchaLikeError> {
+        let engine = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        // 1. Split into 5 base64url parts
+        let parts = jwe.splitn(6, '.').collect::<Vec<&str>>();
+        if parts.len() != 5 {
+            log::info!("Tripwire JWE: expected 5 parts, got {}", parts.len());
+            return Err(CaptchaLikeError::FailedToVerifyCaptcha);
+        }
+        let (b64_header, _b64_enc_key, b64_iv, b64_ciphertext, b64_tag) =
+            (parts[0], parts[1], parts[2], parts[3], parts[4]);
+
+        // 2. Decode header JSON → extract epk x/y coords
+        let header_bytes = engine
+            .decode(b64_header)
+            .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes)
+            .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
+        let epk = header
+            .get("epk")
+            .ok_or(CaptchaLikeError::FailedToVerifyCaptcha)?;
+        let x_b64 = epk
+            .get("x")
+            .and_then(|v| v.as_str())
+            .ok_or(CaptchaLikeError::FailedToVerifyCaptcha)?;
+        let y_b64 = epk
+            .get("y")
+            .and_then(|v| v.as_str())
+            .ok_or(CaptchaLikeError::FailedToVerifyCaptcha)?;
+
+        // 3. Parse server private key from PKCS8 PEM
+        // Normalize literal \n sequences that appear when the key is stored via a single-line
+        // form input or JSON string (e.g. "-----BEGIN PRIVATE KEY-----\nMIG..." with backslash-n).
+        let pem = self.private_key_pem.get().replace("\\n", "\n");
+        let server_sk = P256SecretKey::from_pkcs8_pem(&pem).map_err(|e| {
+            log::error!("Tripwire: failed to parse private key: {e}");
+            CaptchaLikeError::FailedToVerifyCaptcha
+        })?;
+
+        // 4. Reconstruct ephemeral public key: 0x04 || x (32 bytes) || y (32 bytes)
+        let x_bytes = engine
+            .decode(x_b64)
+            .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
+        let y_bytes = engine
+            .decode(y_b64)
+            .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
+        if x_bytes.len() != 32 || y_bytes.len() != 32 {
+            return Err(CaptchaLikeError::FailedToVerifyCaptcha);
+        }
+        let mut uncompressed = Vec::with_capacity(65);
+        uncompressed.push(0x04u8);
+        uncompressed.extend_from_slice(&x_bytes);
+        uncompressed.extend_from_slice(&y_bytes);
+        let epk_pk = P256PublicKey::from_sec1_bytes(&uncompressed)
+            .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
+
+        // 5. ECDH → 32-byte shared secret Z
+        let scalar = server_sk.to_nonzero_scalar();
+        let shared = diffie_hellman(&scalar, epk_pk.as_affine());
+        let z_bytes = shared.raw_secret_bytes();
+
+        // 6. ConcatKDF (RFC 7518 §4.6.2) — single SHA-256 round → 32-byte CEK
+        //    SHA-256(0x00000001 || Z || len32("A256GCM") || "A256GCM" || 0x00000000 || 0x00000000 || 0x00000100)
+        let alg_id = b"A256GCM";
+        let mut hasher = Sha256::new();
+        hasher.update(1u32.to_be_bytes());
+        hasher.update(z_bytes);
+        hasher.update((alg_id.len() as u32).to_be_bytes());
+        hasher.update(alg_id);
+        hasher.update(0u32.to_be_bytes()); // PartyUInfo: empty
+        hasher.update(0u32.to_be_bytes()); // PartyVInfo: empty
+        hasher.update(256u32.to_be_bytes()); // keydatalen = 256 bits
+        let cek = hasher.finalize();
+
+        // 7. AES-256-GCM decrypt (AAD = raw base64url protected header bytes)
+        let iv = engine
+            .decode(b64_iv)
+            .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
+        let ciphertext = engine
+            .decode(b64_ciphertext)
+            .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
+        let tag = engine
+            .decode(b64_tag)
+            .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
+
+        let mut ct_with_tag = ciphertext;
+        ct_with_tag.extend_from_slice(&tag);
+
+        let cipher =
+            Aes256Gcm::new_from_slice(&cek).map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
+        let nonce = aes_gcm::Nonce::from_slice(&iv);
+
+        cipher
+            .decrypt(
+                nonce,
+                Payload {
+                    msg: &ct_with_tag,
+                    aad: b64_header.as_bytes(),
+                },
+            )
+            .map_err(|_| {
+                log::info!(
+                    "Tripwire JWE: AES-GCM decryption failed (tag mismatch or corrupt token)"
+                );
+                CaptchaLikeError::FailedToVerifyCaptcha
+            })
+    }
+}
+
+#[async_trait::async_trait]
+impl CaptchaClient for Layer3IntelTripwireClient {
+    async fn verify_captcha(
+        &self,
+        response: &str,
+        ip_addr: &str,
+    ) -> Result<CaptchaVerificationOutput, CaptchaVerificationError> {
+        // Rule 1: local JWE decryption
+        let plaintext = match self.decrypt_jwe(response) {
+            Ok(b) => b,
+            Err(e) => {
+                log::info!("Tripwire: JWE decryption failed: {e:?}");
+                return Ok(CaptchaVerificationOutput {
+                    result: CaptchaLikeResult::Failure(e),
+                    captured_data: None,
+                    provider: self.name.clone(),
+                });
+            }
+        };
+
+        let assessment: TripwireAssessment = match serde_json::from_slice(&plaintext) {
+            Ok(a) => a,
+            Err(e) => {
+                log::error!("Tripwire: failed to parse assessment JSON: {e}");
+                return Ok(CaptchaVerificationOutput {
+                    result: CaptchaLikeResult::Failure(CaptchaLikeError::FailedToVerifyCaptcha),
+                    captured_data: None,
+                    provider: self.name.clone(),
+                });
+            }
+        };
+
+        let captured_data = self.extract_captured_data(&assessment);
+
+        // Rule 2: proxy check
+        if matches!(assessment.proxy, Some(true)) {
+            log::info!("Tripwire assessment: {assessment:?}");
+            return Ok(CaptchaVerificationOutput {
+                result: CaptchaLikeResult::Failure(CaptchaLikeError::AnonymouseAccess),
+                captured_data,
+                provider: self.name.clone(),
+            });
+        }
+
+        // Rule 3: IP check (prod only, same guard as MonocleClient)
+        if is_prod() {
+            let client_reduced = ReducedIpAddr::from(ip_addr.to_string());
+            let ip_matches = assessment
+                .source_ip
+                .as_deref()
+                .map(|s| ReducedIpAddr::from(s.to_string()) == client_reduced)
+                .unwrap_or(false);
+            if !ip_matches {
+                log::info!("Tripwire assessment: {assessment:?}");
+                return Ok(CaptchaVerificationOutput {
+                    result: CaptchaLikeResult::Failure(CaptchaLikeError::FailedToVerifyIpAddress),
+                    captured_data,
+                    provider: self.name.clone(),
+                });
+            }
+        }
+
+        // Rule 4: timestamp freshness (±300 s)
+        if let Some(ts) = assessment.timestamp {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+            if (now - ts).abs() > 300 {
+                log::info!("Tripwire assessment timestamp out of range: ts={ts}, now={now}");
+                return Ok(CaptchaVerificationOutput {
+                    result: CaptchaLikeResult::Failure(CaptchaLikeError::FailedToVerifyCaptcha),
+                    captured_data,
+                    provider: self.name.clone(),
+                });
+            }
+        }
+
+        Ok(CaptchaVerificationOutput {
+            result: CaptchaLikeResult::Success,
             captured_data,
             provider: self.name.clone(),
         })

--- a/eddist-server/src/external/captcha_like_client.rs
+++ b/eddist-server/src/external/captcha_like_client.rs
@@ -5,12 +5,13 @@ use aes_gcm::{
     aead::{Aead, Payload},
 };
 use base64::Engine;
-use eddist_core::{domain::ip_addr::ReducedIpAddr, utils::is_prod};
+use eddist_core::{domain::ip_addr::ReducedIpAddr, redis_keys::tripwire_uuid_seen_key, utils::is_prod};
 use jsonpath_rust::JsonPath;
 use p256::{
     PublicKey as P256PublicKey, SecretKey as P256SecretKey, ecdh::diffie_hellman,
     pkcs8::DecodePrivateKey,
 };
+use redis::{AsyncCommands, ExistenceCheck, SetExpiry, SetOptions, aio::ConnectionManager};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -62,7 +63,10 @@ fn extract_fields(source: &impl Serialize, fields: &[String]) -> Option<serde_js
 }
 
 /// Factory function to create the appropriate captcha client based on provider config
-pub fn create_captcha_client(config: &CaptchaProviderConfig) -> Box<dyn CaptchaClient> {
+pub fn create_captcha_client(
+    config: &CaptchaProviderConfig,
+    redis_conn: ConnectionManager,
+) -> Box<dyn CaptchaClient> {
     let name = config.name.clone();
     match config.provider.to_lowercase().as_str() {
         "turnstile" => Box::new(TurnstileClient::new(name, config.secret.clone())),
@@ -96,6 +100,7 @@ pub fn create_captcha_client(config: &CaptchaProviderConfig) -> Box<dyn CaptchaC
             name,
             config.secret.clone(),
             config.capture_fields.clone(),
+            redis_conn,
         )),
         // For other providers, use the generic client
         _ => Box::new(GenericCaptchaClient::new(config.clone())),
@@ -343,16 +348,26 @@ impl CaptchaClient for MonocleClient {
 
 pub struct Layer3IntelTripwireClient {
     name: String,
-    private_key_pem: SimpleSecret,
+    private_key: P256SecretKey,
     capture_fields: Vec<String>,
+    redis_conn: ConnectionManager,
 }
 
 impl Layer3IntelTripwireClient {
-    pub fn new(name: String, private_key_pem: String, capture_fields: Vec<String>) -> Self {
+    pub fn new(
+        name: String,
+        private_key_pem: String,
+        capture_fields: Vec<String>,
+        redis_conn: ConnectionManager,
+    ) -> Self {
+        let pem = private_key_pem.replace("\\n", "\n");
+        let private_key = P256SecretKey::from_pkcs8_pem(&pem)
+            .expect("layer3intel_tripwire: invalid PKCS8 EC P-256 private key in config");
         Self {
             name,
-            private_key_pem: SimpleSecret::new(&private_key_pem),
+            private_key,
             capture_fields,
+            redis_conn,
         }
     }
 
@@ -391,16 +406,7 @@ impl Layer3IntelTripwireClient {
             .and_then(|v| v.as_str())
             .ok_or(CaptchaLikeError::FailedToVerifyCaptcha)?;
 
-        // 3. Parse server private key from PKCS8 PEM
-        // Normalize literal \n sequences that appear when the key is stored via a single-line
-        // form input or JSON string (e.g. "-----BEGIN PRIVATE KEY-----\nMIG..." with backslash-n).
-        let pem = self.private_key_pem.get().replace("\\n", "\n");
-        let server_sk = P256SecretKey::from_pkcs8_pem(&pem).map_err(|e| {
-            log::error!("Tripwire: failed to parse private key: {e}");
-            CaptchaLikeError::FailedToVerifyCaptcha
-        })?;
-
-        // 4. Reconstruct ephemeral public key: 0x04 || x (32 bytes) || y (32 bytes)
+        // 3. Reconstruct ephemeral public key: 0x04 || x (32 bytes) || y (32 bytes)
         let x_bytes = engine
             .decode(x_b64)
             .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
@@ -417,12 +423,12 @@ impl Layer3IntelTripwireClient {
         let epk_pk = P256PublicKey::from_sec1_bytes(&uncompressed)
             .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
 
-        // 5. ECDH → 32-byte shared secret Z
-        let scalar = server_sk.to_nonzero_scalar();
+        // 4. ECDH → 32-byte shared secret Z
+        let scalar = self.private_key.to_nonzero_scalar();
         let shared = diffie_hellman(&scalar, epk_pk.as_affine());
         let z_bytes = shared.raw_secret_bytes();
 
-        // 6. ConcatKDF (RFC 7518 §4.6.2) — single SHA-256 round → 32-byte CEK
+        // 5. ConcatKDF (RFC 7518 §4.6.2) — single SHA-256 round → 32-byte CEK
         //    SHA-256(0x00000001 || Z || len32("A256GCM") || "A256GCM" || 0x00000000 || 0x00000000 || 0x00000100)
         let alg_id = b"A256GCM";
         let mut hasher = Sha256::new();
@@ -435,7 +441,7 @@ impl Layer3IntelTripwireClient {
         hasher.update(256u32.to_be_bytes()); // keydatalen = 256 bits
         let cek = hasher.finalize();
 
-        // 7. AES-256-GCM decrypt (AAD = raw base64url protected header bytes)
+        // 6. AES-256-GCM decrypt (AAD = raw base64url protected header bytes)
         let iv = engine
             .decode(b64_iv)
             .map_err(|_| CaptchaLikeError::FailedToVerifyCaptcha)?;
@@ -540,6 +546,28 @@ impl CaptchaClient for Layer3IntelTripwireClient {
                 .unwrap_or(0);
             if (now - ts).abs() > 300 {
                 log::info!("Tripwire assessment timestamp out of range: ts={ts}, now={now}");
+                return Ok(CaptchaVerificationOutput {
+                    result: CaptchaLikeResult::Failure(CaptchaLikeError::FailedToVerifyCaptcha),
+                    captured_data,
+                    provider: self.name.clone(),
+                });
+            }
+        }
+
+        // Rule 5: replay prevention — atomically claim the UUID (SET NX EX 600)
+        if let Some(uuid) = assessment.uuid.as_deref() {
+            let key = tripwire_uuid_seen_key(uuid);
+            let opts = SetOptions::default()
+                .conditional_set(ExistenceCheck::NX)
+                .with_expiration(SetExpiry::EX(600));
+            let newly_set: Option<String> = self
+                .redis_conn
+                .clone()
+                .set_options(&key, 1u8, opts)
+                .await
+                .unwrap_or(Some("OK".to_string())); // on Redis error, allow through
+            if newly_set.is_none() {
+                log::info!("Tripwire: replayed UUID detected: {uuid}");
                 return Ok(CaptchaVerificationOutput {
                     result: CaptchaLikeResult::Failure(CaptchaLikeError::FailedToVerifyCaptcha),
                     captured_data,

--- a/eddist-server/src/repositories/captcha_config_repository.rs
+++ b/eddist-server/src/repositories/captcha_config_repository.rs
@@ -60,6 +60,36 @@ fn get_default_widget_config(
             widget_html: String::new(),
             script_handler: None,
         }),
+        "layer3intel_tripwire" => Some(CaptchaWidgetMetadata {
+            form_field_name: "tripwire_token".to_string(),
+            script_url: format!(
+                "https://cdn.layer3intel.com/tripwire.min.js?key={}",
+                site_key
+            ),
+            widget_html: String::new(),
+            // Intercept form submission manually so token injection is not sensitive
+            // to when the async script finishes loading relative to DOMContentLoaded.
+            script_handler: Some(
+                r#"(function() {
+  var form = document.getElementById('login-form');
+  form.addEventListener('submit', function(e) {
+    if (document.querySelector('input[name="tripwire_token"]')) return;
+    if (typeof window.Tripwire === 'undefined') return;
+    e.preventDefault();
+    var self = this;
+    window.Tripwire.run().then(function(result) {
+      var input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = 'tripwire_token';
+      input.value = result.token;
+      self.appendChild(input);
+      self.submit();
+    }).catch(function() { self.submit(); });
+  });
+})();"#
+                    .to_string(),
+            ),
+        }),
         _ => None,
     }
 }

--- a/eddist-server/src/services/auth_with_code_service.rs
+++ b/eddist-server/src/services/auth_with_code_service.rs
@@ -91,7 +91,7 @@ impl<T: BbsRepository, E: CreationEventRepository>
             };
             let provider_type = config.provider.to_lowercase();
             clients_responses.push((
-                create_captcha_client(config),
+                create_captcha_client(config, self.redis_conn.clone()),
                 (response, input.origin_ip.clone()),
                 provider_type,
             ));


### PR DESCRIPTION

Implements Layer3Intel Tripwire as a first-class captcha provider. Verification is done entirely server-side by decrypting the JWE token (ECDH-ES + A256GCM) using a local EC P-256 private key — no outbound API call.

- Add Layer3IntelTripwireClient with decrypt_jwe() implementing ConcatKDF (RFC 7518 §4.6.2) + AES-256-GCM using pure-Rust RustCrypto crates (p256, aes-gcm)
- Validate proxy flag, source_ip match (ReducedIpAddr, is_prod() guard), and timestamp freshness (±300s); mirrors MonocleClient patterns
- Add TripwireAssessment domain struct (proxy, proxy_type, timestamp, source_ip, key, uuid)
- Register default widget config in get_default_widget_config(): uses manual Tripwire.run() submit interceptor to avoid async script timing issues
- Normalize literal \n in stored PEM keys before parsing
- Add layer3intel_tripwire to admin frontend KNOWN_PROVIDERS and FIRST_CLASS_PROVIDERS; add green badge color
- Update captcha-config.example.json