### PR TITLE
fix: add endpoint_usage field to captcha config form in admin UI

### DIFF
--- a/eddist-admin/client/app/components/CaptchaConfigForm.tsx
+++ b/eddist-admin/client/app/components/CaptchaConfigForm.tsx
@@ -131,6 +131,18 @@ const CaptchaConfigForm = (props: Props) => {
           </div>
         </div>
 
+        <div>
+          <Label>Endpoint Usage</Label>
+          <Select
+            {...register("endpoint_usage")}
+            defaultValue={defaults?.endpoint_usage ?? "auth_code"}
+          >
+            <option value="auth_code">auth_code (posting new threads/replies)</option>
+            <option value="re_auth">re_auth (re-authentication)</option>
+            <option value="all">all (both endpoints)</option>
+          </Select>
+        </div>
+
         <div className="grid grid-cols-2 gap-4">
           <div>
             <Label>Site Key</Label>

--- a/eddist-admin/client/app/routes/dashboard.captcha-configs.tsx
+++ b/eddist-admin/client/app/routes/dashboard.captcha-configs.tsx
@@ -71,6 +71,7 @@ const CaptchaConfigs = () => {
             <TableHeadCell>Name</TableHeadCell>
             <TableHeadCell>Provider</TableHeadCell>
             <TableHeadCell>Site Key</TableHeadCell>
+            <TableHeadCell>Endpoint</TableHeadCell>
             <TableHeadCell>Status</TableHeadCell>
             <TableHeadCell>Order</TableHeadCell>
             <TableHeadCell>Actions</TableHeadCell>
@@ -86,6 +87,19 @@ const CaptchaConfigs = () => {
                   <code className="text-sm text-gray-600 max-w-xs truncate block">
                     {config.site_key}
                   </code>
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    color={
+                      config.endpoint_usage === "re_auth"
+                        ? "indigo"
+                        : config.endpoint_usage === "all"
+                          ? "purple"
+                          : "blue"
+                    }
+                  >
+                    {config.endpoint_usage}
+                  </Badge>
                 </TableCell>
                 <TableCell>
                   <Badge color={config.is_active ? "success" : "gray"}>


### PR DESCRIPTION
- Add Endpoint Usage select field to CaptchaConfigForm with options for auth_code, re_auth, and all
- Add Endpoint column to the captcha configs table for visibility
- The field was already supported by the backend and OpenAPI schema but was missing from the frontend form, making it impossible to configure which endpoint(s) a captcha config applies to

