### PR TITLE
fix: show error modal on non-200 responses

### DIFF
--- a/eddist-server/client-v2/app/components/utils.ts
+++ b/eddist-server/client-v2/app/components/utils.ts
@@ -184,7 +184,13 @@ const afterPost = async (res: Response): Promise<PostResponseResult> => {
         },
       };
     }
-    throw new Error(`Failed to post a response: ${res.statusText}`);
+    return {
+      success: false,
+      error: {
+        kind: "unknown",
+        errorHtml: text || `${res.status} ${res.statusText}`,
+      },
+    };
   }
 
   if (text.includes("error_code")) {


### PR DESCRIPTION
- Return PostResponseFailure instead of throwing for non-200 responses without error_code in the body (e.g. 403 Access denied from middleware, 404 Not Found from invalid board key)
