### PR TITLE
feat: implement safe mode thread filtering (phase 2)

### DIFF
--- a/.sqlx/query-7be3c04f4c3750aa147456eb31343459772f90c43bd6945639cb9f57a6c19bd1.json
+++ b/.sqlx/query-7be3c04f4c3750aa147456eb31343459772f90c43bd6945639cb9f57a6c19bd1.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "MySQL",
+  "query": "\n            SELECT thread_number\n            FROM threads\n            WHERE board_id = (SELECT id FROM boards WHERE board_key = ?)\n            AND active = 0\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "thread_number",
+        "type_info": {
+          "type": "LongLong",
+          "flags": "NOT_NULL | MULTIPLE_KEY | NO_DEFAULT_VALUE",
+          "max_size": 20
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "7be3c04f4c3750aa147456eb31343459772f90c43bd6945639cb9f57a6c19bd1"
+}

--- a/.sqlx/query-b802fb7223b80484fdb38c580737983a50b1a47bc3040e3f28e80bb9f742075e.json
+++ b/.sqlx/query-b802fb7223b80484fdb38c580737983a50b1a47bc3040e3f28e80bb9f742075e.json
@@ -1,10 +1,19 @@
 {
   "db_name": "MySQL",
-  "query": "\n            SELECT\n                b.board_key AS board_key,\n                b.default_name AS default_name,\n                bi.threads_archive_cron AS threads_archive_cron,\n                bi.threads_archive_trigger_thread_count AS threads_archive_trigger_thread_count,\n                bi.enable_1001_message AS \"enable_1001_message: bool\",\n                bi.custom_1001_message AS custom_1001_message\n            FROM\n                boards AS b\n            JOIN\n                boards_info AS bi\n            ON\n                b.id = bi.id\n            ",
+  "query": "\n            SELECT\n                BIN_TO_UUID(b.id) AS \"board_id!: Uuid\",\n                b.board_key AS board_key,\n                b.default_name AS default_name,\n                bi.threads_archive_cron AS threads_archive_cron,\n                bi.threads_archive_trigger_thread_count AS threads_archive_trigger_thread_count,\n                bi.enable_1001_message AS \"enable_1001_message: bool\",\n                bi.custom_1001_message AS custom_1001_message\n            FROM\n                boards AS b\n            JOIN\n                boards_info AS bi\n            ON\n                b.id = bi.id\n            ",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
+        "name": "board_id!: Uuid",
+        "type_info": {
+          "type": "VarString",
+          "flags": "",
+          "max_size": 144
+        }
+      },
+      {
+        "ordinal": 1,
         "name": "board_key",
         "type_info": {
           "type": "VarString",
@@ -13,7 +22,7 @@
         }
       },
       {
-        "ordinal": 1,
+        "ordinal": 2,
         "name": "default_name",
         "type_info": {
           "type": "Blob",
@@ -22,7 +31,7 @@
         }
       },
       {
-        "ordinal": 2,
+        "ordinal": 3,
         "name": "threads_archive_cron",
         "type_info": {
           "type": "VarString",
@@ -31,7 +40,7 @@
         }
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "threads_archive_trigger_thread_count",
         "type_info": {
           "type": "Long",
@@ -40,7 +49,7 @@
         }
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "enable_1001_message: bool",
         "type_info": {
           "type": "Tiny",
@@ -49,7 +58,7 @@
         }
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "custom_1001_message",
         "type_info": {
           "type": "Blob",
@@ -62,6 +71,7 @@
       "Right": 0
     },
     "nullable": [
+      true,
       false,
       false,
       true,
@@ -70,5 +80,5 @@
       true
     ]
   },
-  "hash": "3bb95a502a62f14f869b3fd3c0a1d154499919e1e62ae5c8b0d2c9307f82e401"
+  "hash": "b802fb7223b80484fdb38c580737983a50b1a47bc3040e3f28e80bb9f742075e"
 }

--- a/eddist-admin/client/app/routes/dashboard.server-settings.tsx
+++ b/eddist-admin/client/app/routes/dashboard.server-settings.tsx
@@ -55,6 +55,13 @@ const KNOWN_SETTINGS: SettingDefinition[] = [
       "Run OpenAI content moderation on each new thread (title + body) before publishing the creation event.",
     type: "boolean",
   },
+  {
+    key: "bbs.enable_safe_mode",
+    label: "Enable Safe Mode",
+    description:
+      "Enable safe mode thread filtering. Hides threads with unsafe content from clients that support it.",
+    type: "boolean",
+  },
 ];
 
 const MASKED_VALUE = "***";

--- a/eddist-core/src/redis_keys.rs
+++ b/eddist-core/src/redis_keys.rs
@@ -70,6 +70,10 @@ pub fn reauth_lock_key(token_id: &str) -> String {
     format!("reauth:lock:{token_id}")
 }
 
+pub fn unsafe_threads_key(board_id: impl std::fmt::Display) -> String {
+    format!("bbs:safe_mode:unsafe_threads:{board_id}")
+}
+
 pub const DB_FAILED_CACHE_RES_KEY: &str = "bbs:db_failed_cache:res";
 
 pub const CHANNEL_RES_CREATED: &str = "bbs:event:res_created";

--- a/eddist-core/src/server_settings.rs
+++ b/eddist-core/src/server_settings.rs
@@ -3,6 +3,7 @@ pub const KEY_REQUIRE_IDP_LINKING: &str = "user.require_idp_linking";
 pub const KEY_AI_OPENAI_API_KEY: &str = "ai.openai_api_key";
 pub const KEY_AI_MODERATION_ON_RES: &str = "ai.moderation_on_res";
 pub const KEY_AI_MODERATION_ON_THREAD: &str = "ai.moderation_on_thread";
+pub const KEY_ENABLE_SAFE_MODE: &str = "bbs.enable_safe_mode";
 
 pub enum ServerSettingKey {
     EnableIdpLinking,
@@ -10,6 +11,7 @@ pub enum ServerSettingKey {
     AiOpenAiApiKey,
     AiModerationOnRes,
     AiModerationOnThread,
+    EnableSafeMode,
 }
 
 impl ServerSettingKey {
@@ -20,6 +22,7 @@ impl ServerSettingKey {
             Self::AiOpenAiApiKey => KEY_AI_OPENAI_API_KEY,
             Self::AiModerationOnRes => KEY_AI_MODERATION_ON_RES,
             Self::AiModerationOnThread => KEY_AI_MODERATION_ON_THREAD,
+            Self::EnableSafeMode => KEY_ENABLE_SAFE_MODE,
         }
     }
 
@@ -29,6 +32,7 @@ impl ServerSettingKey {
         ServerSettingKey::AiOpenAiApiKey,
         ServerSettingKey::AiModerationOnRes,
         ServerSettingKey::AiModerationOnThread,
+        ServerSettingKey::EnableSafeMode,
     ];
 
     pub const fn description(&self) -> &'static str {
@@ -45,6 +49,9 @@ impl ServerSettingKey {
             }
             Self::AiModerationOnThread => {
                 "Enable OpenAI content moderation for thread creation (true/false)"
+            }
+            Self::EnableSafeMode => {
+                "Enable safe mode thread filtering — hides threads with unsafe content from clients that support it (true/false)"
             }
         }
     }

--- a/eddist-cron/src/main.rs
+++ b/eddist-cron/src/main.rs
@@ -10,9 +10,7 @@ use aws_sdk_s3::{
 use chrono::{TimeDelta, TimeZone, Timelike, Utc};
 use cron::Schedule;
 use eddist_core::{
-    domain::res::get_1001_sjis_bytes,
-    redis_keys::unsafe_threads_key,
-    tracing::init_tracing,
+    domain::res::get_1001_sjis_bytes, redis_keys::unsafe_threads_key, tracing::init_tracing,
     utils::is_prod,
 };
 use redis::AsyncCommands;

--- a/eddist-cron/src/main.rs
+++ b/eddist-cron/src/main.rs
@@ -9,7 +9,13 @@ use aws_sdk_s3::{
 };
 use chrono::{TimeDelta, TimeZone, Timelike, Utc};
 use cron::Schedule;
-use eddist_core::{domain::res::get_1001_sjis_bytes, tracing::init_tracing, utils::is_prod};
+use eddist_core::{
+    domain::res::get_1001_sjis_bytes,
+    redis_keys::unsafe_threads_key,
+    tracing::init_tracing,
+    utils::is_prod,
+};
+use redis::AsyncCommands;
 use sqlx::mysql::MySqlPoolOptions;
 use tokio::time::sleep;
 
@@ -64,6 +70,12 @@ async fn main() {
             // inactivate and archive
             // - inactivate (set active to false, archived to true)
 
+            let redis_conn = redis::Client::open(env::var("REDIS_URL").unwrap())
+                .unwrap()
+                .get_connection_manager()
+                .await
+                .unwrap();
+
             let boards = repo.get_all_boards_info().await.unwrap();
             let mut tasks = Vec::new();
 
@@ -102,30 +114,49 @@ async fn main() {
 
                     // Create parallel task for each board
                     let repo_clone = repo.clone();
+                    let mut redis_conn = redis_conn.clone();
                     let board_key = b.board_key.clone();
+                    let board_id = b.board_id;
 
                     let task = tokio::spawn(async move {
                         // Randomize thread archive timing (0-59 seconds)
                         let random_delay = rand::random::<u64>() % 60;
                         sleep(Duration::from_secs(random_delay)).await;
 
-                        match repo_clone
+                        if let Err(e) = repo_clone
                             .update_threads_to_inactive(&board_key, trigger as u32)
                             .await
                         {
-                            Ok(_) => {
-                                log::info!(
-                                    "`inactivate` Cronjob for board: {board_key} is executed"
-                                );
-                                Ok(())
+                            log::error!("`inactivate` Cronjob for board: {board_key} failed: {e}");
+                            return Err(e);
+                        }
+
+                        log::info!("`inactivate` Cronjob for board: {board_key} is executed");
+
+                        // Purge newly inactive threads from the safe-mode unsafe set
+                        match repo_clone
+                            .get_inactive_thread_numbers_for_board(&board_key)
+                            .await
+                        {
+                            Ok(thread_numbers) if !thread_numbers.is_empty() => {
+                                let key = unsafe_threads_key(board_id);
+                                if let Err(e) =
+                                    redis_conn.srem::<_, _, ()>(&key, thread_numbers).await
+                                {
+                                    log::error!(
+                                        "Failed to purge unsafe threads for board {board_key}: {e}"
+                                    );
+                                }
                             }
+                            Ok(_) => {}
                             Err(e) => {
                                 log::error!(
-                                    "`inactivate` Cronjob for board: {board_key} failed: {e}"
+                                    "Failed to get inactive thread numbers for board {board_key}: {e}"
                                 );
-                                Err(e)
                             }
                         }
+
+                        Ok(())
                     });
 
                     tasks.push(task);

--- a/eddist-cron/src/repository.rs
+++ b/eddist-cron/src/repository.rs
@@ -19,6 +19,7 @@ impl Repository {
             SelectionBoardInfo,
             r#"
             SELECT
+                BIN_TO_UUID(b.id) AS "board_id!: Uuid",
                 b.board_key AS board_key,
                 b.default_name AS default_name,
                 bi.threads_archive_cron AS threads_archive_cron,
@@ -36,6 +37,24 @@ impl Repository {
         .fetch_all(&self.0)
         .await?;
         Ok(boards)
+    }
+
+    pub async fn get_inactive_thread_numbers_for_board(
+        &self,
+        board_key: &str,
+    ) -> anyhow::Result<Vec<u64>> {
+        let numbers = sqlx::query_scalar!(
+            r#"
+            SELECT thread_number
+            FROM threads
+            WHERE board_id = (SELECT id FROM boards WHERE board_key = ?)
+            AND active = 0
+            "#,
+            board_key,
+        )
+        .fetch_all(&self.0)
+        .await?;
+        Ok(numbers.into_iter().map(|n| n as u64).collect())
     }
 
     pub async fn update_threads_to_inactive(
@@ -373,6 +392,7 @@ struct Res {
 
 #[derive(Debug, Clone)]
 pub struct SelectionBoardInfo {
+    pub board_id: Uuid,
     pub board_key: String,
     pub default_name: String,
     pub threads_archive_cron: Option<String>,

--- a/eddist-persistence/src/subscriber.rs
+++ b/eddist-persistence/src/subscriber.rs
@@ -4,8 +4,8 @@ use eddist_core::{
     domain::pubsub_repository::{
         CHANNEL_AUTH_TOKEN_REVOKED, CHANNEL_AUTH_TOKEN_SUCCEEDED, CHANNEL_PUBSUB_ITEM, PubSubItem,
     },
-    proto::{decode_auth_token_revoked, decode_auth_token_succeeded},
-    redis_keys::DB_FAILED_CACHE_RES_KEY,
+    proto::{decode_auth_token_revoked, decode_auth_token_succeeded, decode_creating_thread},
+    redis_keys::{CHANNEL_THREAD_CREATED, DB_FAILED_CACHE_RES_KEY, unsafe_threads_key},
 };
 use futures::StreamExt;
 use redis::AsyncCommands;
@@ -55,7 +55,7 @@ impl SubRepository for RedisSubRepository {
         let mut error_count = 0u32;
         let redis_url = env::var("REDIS_URL").unwrap();
         let backup_enabled = self.s3_bucket.is_some();
-        let mut channels: Vec<&str> = vec![CHANNEL_PUBSUB_ITEM];
+        let mut channels = vec![CHANNEL_PUBSUB_ITEM, CHANNEL_THREAD_CREATED];
         if backup_enabled {
             channels.push(CHANNEL_AUTH_TOKEN_SUCCEEDED);
             channels.push(CHANNEL_AUTH_TOKEN_REVOKED);
@@ -237,6 +237,46 @@ impl RedisSubRepository {
                                 warn!("Failed to backup token {token_id}: {e}");
                             }
                         });
+                    }
+                }
+                ch if ch == CHANNEL_THREAD_CREATED => {
+                    let payload = match msg.get_payload::<Vec<u8>>() {
+                        Ok(p) => p,
+                        Err(e) => {
+                            error!(
+                                error = e.to_string().as_str(),
+                                "Failed to get thread_created payload"
+                            );
+                            continue;
+                        }
+                    };
+
+                    let event = match decode_creating_thread(&payload) {
+                        Ok(e) => e,
+                        Err(e) => {
+                            error!(
+                                error = e.to_string().as_str(),
+                                "Failed to decode CreatingThread"
+                            );
+                            continue;
+                        }
+                    };
+
+                    if event.moderation_result.map(|m| m.flagged).unwrap_or(false) {
+                        let key = unsafe_threads_key(event.board_id);
+                        let mut conn = self.conn.clone();
+                        if let Err(e) = conn.sadd::<_, _, ()>(&key, event.unix_time).await {
+                            error!(
+                                error = e.to_string().as_str(),
+                                "Failed to add unsafe thread to Redis set"
+                            );
+                        } else {
+                            info!(
+                                board_id = event.board_id.to_string().as_str(),
+                                unix_time = event.unix_time,
+                                "Flagged thread stored in safe mode set"
+                            );
+                        }
                     }
                 }
                 ch if ch == CHANNEL_AUTH_TOKEN_REVOKED => {

--- a/eddist-server/client-v2/app/api-client/client-config.ts
+++ b/eddist-server/client-v2/app/api-client/client-config.ts
@@ -1,5 +1,6 @@
 export interface ClientConfig {
   enable_user_registration: boolean;
+  enable_safe_mode: boolean;
 }
 
 let _clientConfigCache: { data: ClientConfig; expiresAt: number } | null = null;

--- a/eddist-server/client-v2/app/api-client/safe_mode.ts
+++ b/eddist-server/client-v2/app/api-client/safe_mode.ts
@@ -1,0 +1,15 @@
+export const fetchUnsafeThreadIds = async (
+  boardKey: string,
+  options?: { baseUrl?: string },
+): Promise<Set<number>> => {
+  const base = (import.meta.env.SSR && options?.baseUrl) || "";
+  try {
+    const res = await fetch(`${base}/api/${boardKey}/unsafe-thread-ids`);
+    if (!res.ok) return new Set();
+    const data = await res.json();
+    return new Set<number>(data.thread_ids ?? []);
+  } catch (e) {
+    console.error("fetchUnsafeThreadIds failed:", e);
+    return new Set();
+  }
+};

--- a/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
+++ b/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
@@ -2,6 +2,7 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Tooltip } from "flo
 import { useState } from "react";
 import { FaDesktop, FaMoon, FaSun } from "react-icons/fa";
 import { HiInformationCircle } from "react-icons/hi";
+import { useRevalidator } from "react-router";
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useTheme } from "~/contexts/ThemeContext";
 import { parseCookie } from "~/utils/cookie";
@@ -11,6 +12,7 @@ import { Tabs } from "./Tabs";
 interface NGWordsSettingsModalProps {
   open: boolean;
   setOpen: (open: boolean) => void;
+  enableSafeMode: boolean;
 }
 
 const ThemeTab = () => {
@@ -46,18 +48,21 @@ const ThemeTab = () => {
 };
 
 const SafeModeTab = () => {
-  const [safeMode] = useState(() => {
+  const { revalidate } = useRevalidator();
+  const [safeMode, setSafeMode] = useState(() => {
     if (typeof document === "undefined") return true;
     return parseCookie(document.cookie, "safe_mode") !== "off";
   });
 
   const handleToggle = () => {
-    if (safeMode) {
-      document.cookie = "safe_mode=off; path=/; max-age=31536000; SameSite=Lax";
-    } else {
+    const next = !safeMode;
+    if (next) {
       document.cookie = "safe_mode=; path=/; max-age=0; SameSite=Lax";
+    } else {
+      document.cookie = "safe_mode=off; path=/; max-age=31536000; SameSite=Lax";
     }
-    window.location.reload();
+    setSafeMode(next);
+    revalidate();
   };
 
   return (
@@ -86,7 +91,11 @@ const SafeModeTab = () => {
   );
 };
 
-export const NGWordsSettingsModal = ({ open, setOpen }: NGWordsSettingsModalProps) => {
+export const NGWordsSettingsModal = ({
+  open,
+  setOpen,
+  enableSafeMode,
+}: NGWordsSettingsModalProps) => {
   const { config, addRule, updateRule, removeRule, toggleRule, clearAllRules } = useNGWords();
 
   return (
@@ -168,11 +177,9 @@ export const NGWordsSettingsModal = ({ open, setOpen }: NGWordsSettingsModalProp
               title: "テーマ",
               content: <ThemeTab />,
             },
-            {
-              id: "safe-mode",
-              title: "セーフモード",
-              content: <SafeModeTab />,
-            },
+            ...(enableSafeMode
+              ? [{ id: "safe-mode", title: "セーフモード", content: <SafeModeTab /> }]
+              : []),
           ]}
         />
       </ModalBody>

--- a/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
+++ b/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
@@ -1,8 +1,10 @@
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Tooltip } from "flowbite-react";
+import { useState } from "react";
 import { FaDesktop, FaMoon, FaSun } from "react-icons/fa";
 import { HiInformationCircle } from "react-icons/hi";
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useTheme } from "~/contexts/ThemeContext";
+import { parseCookie } from "~/utils/cookie";
 import { NGRuleSection } from "./NGRuleSection";
 import { Tabs } from "./Tabs";
 
@@ -39,6 +41,47 @@ const ThemeTab = () => {
           </label>
         ))}
       </div>
+    </div>
+  );
+};
+
+const SafeModeTab = () => {
+  const [safeMode] = useState(() => {
+    if (typeof document === "undefined") return true;
+    return parseCookie(document.cookie, "safe_mode") !== "off";
+  });
+
+  const handleToggle = () => {
+    if (safeMode) {
+      document.cookie = "safe_mode=off; path=/; max-age=31536000; SameSite=Lax";
+    } else {
+      document.cookie = "safe_mode=; path=/; max-age=0; SameSite=Lax";
+    }
+    window.location.reload();
+  };
+
+  return (
+    <div className="py-2 dark:text-gray-100">
+      <h3 className="text-lg font-semibold mb-2">セーフモード</h3>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        ONのとき、不適切と判定されたスレッドをスレッド一覧から非表示にします。スレッドURLへの直接アクセスは引き続き可能です。
+      </p>
+      <label className="flex items-center gap-3 cursor-pointer select-none">
+        <div className="relative">
+          <input type="checkbox" className="sr-only" checked={safeMode} onChange={handleToggle} />
+          <div
+            className={`w-11 h-6 rounded-full transition-colors ${
+              safeMode ? "bg-blue-600" : "bg-gray-300 dark:bg-gray-600"
+            }`}
+          />
+          <div
+            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+              safeMode ? "translate-x-5" : ""
+            }`}
+          />
+        </div>
+        <span className="font-medium">セーフモード: {safeMode ? "ON" : "OFF"}</span>
+      </label>
     </div>
   );
 };
@@ -124,6 +167,11 @@ export const NGWordsSettingsModal = ({ open, setOpen }: NGWordsSettingsModalProp
               id: "theme",
               title: "テーマ",
               content: <ThemeTab />,
+            },
+            {
+              id: "safe-mode",
+              title: "セーフモード",
+              content: <SafeModeTab />,
             },
           ]}
         />

--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -74,17 +74,21 @@ export const loader = async ({ params, request, context }: Route.LoaderArgs) => 
     fetchBoards({ baseUrl }),
     fetchClientConfig({ baseUrl }).catch(() => ({
       enable_user_registration: false,
+      enable_safe_mode: false,
     })),
     safeMode
       ? fetchUnsafeThreadIds(params.boardKey ?? "", { baseUrl })
       : Promise.resolve(new Set<number>()),
   ]);
 
+  const enableSafeMode = clientConfig.enable_safe_mode;
+
   return {
     threadList,
     boards,
     currentTime: Date.now(),
-    safeMode,
+    safeMode: safeMode && enableSafeMode,
+    enableSafeMode,
     unsafeThreadIds: Array.from(unsafeThreadIds),
     eddistData: {
       bbsName: context.BBS_NAME ?? "エッヂ掲示板",
@@ -95,6 +99,7 @@ export const loader = async ({ params, request, context }: Route.LoaderArgs) => 
     boards: Board[];
     currentTime: number;
     safeMode: boolean;
+    enableSafeMode: boolean;
     unsafeThreadIds: number[];
     eddistData: {
       bbsName: string;
@@ -114,7 +119,15 @@ const Meta = ({ bbsName, boardName }: { bbsName: string; boardName: string }) =>
 );
 
 const ThreadListPage = ({
-  loaderData: { threadList: data, boards, currentTime, safeMode, unsafeThreadIds, eddistData },
+  loaderData: {
+    threadList: data,
+    boards,
+    currentTime,
+    safeMode,
+    enableSafeMode,
+    unsafeThreadIds,
+    eddistData,
+  },
 }: Route.ComponentProps) => {
   const params = useParams();
 
@@ -271,16 +284,6 @@ const ThreadListPage = ({
             className={twMerge("w-4 h-4", (isRefreshing || isPullRefreshing) && "animate-spin")}
           />
         </button>
-        {safeMode && (
-          <button
-            type="button"
-            onClick={openNGSettings}
-            className="hidden lg:flex px-2 py-1 mx-1 text-xs rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-700 items-center gap-1 cursor-pointer"
-            title="セーフモード有効 — クリックして設定"
-          >
-            セーフモード
-          </button>
-        )}
         <button
           type="button"
           onClick={openNGSettings}
@@ -327,7 +330,11 @@ const ThreadListPage = ({
 
         {hasEverOpenedNGSettings.current && (
           <Suspense fallback={null}>
-            <LazyNGWordsSettingsModal open={showNGSettings} setOpen={setShowNGSettings} />
+            <LazyNGWordsSettingsModal
+              open={showNGSettings}
+              setOpen={setShowNGSettings}
+              enableSafeMode={enableSafeMode}
+            />
           </Suspense>
         )}
       </header>

--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -6,10 +6,12 @@ import useSWR from "swr";
 import { twMerge } from "tailwind-merge";
 import { type Board, fetchBoards } from "~/api-client/board";
 import { fetchClientConfig } from "~/api-client/client-config";
+import { fetchUnsafeThreadIds } from "~/api-client/safe_mode";
 import { fetchThreadList, type Thread } from "~/api-client/thread_list";
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useContextMenu } from "~/hooks/useContextMenu";
 import { usePullToRefresh } from "~/hooks/usePullToRefresh";
+import { parseCookie } from "~/utils/cookie";
 import { getSelectedTextInElement } from "~/utils/selection";
 import { NGContextMenu } from "../components/NGContextMenu";
 import type { Route } from "./+types/ThreadListPage";
@@ -59,21 +61,31 @@ const calculateThreadSpeed = (
   return Math.round(speed * 100) / 100;
 };
 
-export const loader = async ({ params, context }: Route.LoaderArgs) => {
+export const loader = async ({ params, request, context }: Route.LoaderArgs) => {
   const baseUrl = context.EDDIST_SERVER_URL ?? import.meta.env.VITE_EDDIST_SERVER_URL;
 
-  const [threadList, boards, clientConfig] = await Promise.all([
+  const url = new URL(request.url);
+  const isFull = url.searchParams.get("_v") === "full";
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const safeMode = !isFull && parseCookie(cookieHeader, "safe_mode") !== "off";
+
+  const [threadList, boards, clientConfig, unsafeThreadIds] = await Promise.all([
     fetchThreadList(params.boardKey ?? "", { baseUrl }),
     fetchBoards({ baseUrl }),
     fetchClientConfig({ baseUrl }).catch(() => ({
       enable_user_registration: false,
     })),
+    safeMode
+      ? fetchUnsafeThreadIds(params.boardKey ?? "", { baseUrl })
+      : Promise.resolve(new Set<number>()),
   ]);
 
   return {
     threadList,
     boards,
     currentTime: Date.now(),
+    safeMode,
+    unsafeThreadIds: Array.from(unsafeThreadIds),
     eddistData: {
       bbsName: context.BBS_NAME ?? "エッヂ掲示板",
       availableUserRegistration: clientConfig.enable_user_registration,
@@ -82,6 +94,8 @@ export const loader = async ({ params, context }: Route.LoaderArgs) => {
     threadList: Thread[];
     boards: Board[];
     currentTime: number;
+    safeMode: boolean;
+    unsafeThreadIds: number[];
     eddistData: {
       bbsName: string;
       availableUserRegistration: boolean;
@@ -100,7 +114,7 @@ const Meta = ({ bbsName, boardName }: { bbsName: string; boardName: string }) =>
 );
 
 const ThreadListPage = ({
-  loaderData: { threadList: data, boards, currentTime, eddistData },
+  loaderData: { threadList: data, boards, currentTime, safeMode, unsafeThreadIds, eddistData },
 }: Route.ComponentProps) => {
   const params = useParams();
 
@@ -123,6 +137,7 @@ const ThreadListPage = ({
   const hasEverOpenedNGSettings = useRef(false);
 
   const { shouldFilterThread } = useNGWords();
+  const unsafeSet = useMemo(() => new Set(unsafeThreadIds), [unsafeThreadIds]);
   const { menuState, closeMenu, contextMenuHandlers } = useContextMenu();
   const [contextMenuThread, setContextMenuThread] = useState<Thread | null>(null);
   const [selectedTitleText, setSelectedTitleText] = useState<string | null>(null);
@@ -148,6 +163,11 @@ const ThreadListPage = ({
     enabled: true,
     scrollTarget: "window",
   });
+
+  const openNGSettings = () => {
+    hasEverOpenedNGSettings.current = true;
+    setShowNGSettings(true);
+  };
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -188,8 +208,10 @@ const ThreadListPage = ({
   }, [threadList, sortKey, sortOrder, currentTime]);
 
   const filteredThreadList = useMemo(() => {
-    return sortedThreadList.filter((thread) => !shouldFilterThread(thread));
-  }, [sortedThreadList, shouldFilterThread]);
+    return sortedThreadList.filter(
+      (thread) => !shouldFilterThread(thread) && !(safeMode && unsafeSet.has(thread.id)),
+    );
+  }, [sortedThreadList, shouldFilterThread, safeMode, unsafeSet]);
 
   return (
     <div className="relative pt-16 min-h-screen dark:bg-gray-900 dark:text-gray-100">
@@ -249,12 +271,19 @@ const ThreadListPage = ({
             className={twMerge("w-4 h-4", (isRefreshing || isPullRefreshing) && "animate-spin")}
           />
         </button>
+        {safeMode && (
+          <button
+            type="button"
+            onClick={openNGSettings}
+            className="hidden lg:flex px-2 py-1 mx-1 text-xs rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-700 items-center gap-1 cursor-pointer"
+            title="セーフモード有効 — クリックして設定"
+          >
+            セーフモード
+          </button>
+        )}
         <button
           type="button"
-          onClick={() => {
-            hasEverOpenedNGSettings.current = true;
-            setShowNGSettings(true);
-          }}
+          onClick={openNGSettings}
           className="px-3 py-2 lg:px-4 lg:py-2 mx-1 lg:mx-2 text-sm lg:text-base rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5"
           title="NG設定"
         >

--- a/eddist-server/client-v2/app/routes/ThreadPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadPage.tsx
@@ -53,6 +53,7 @@ export const loader = async ({ params, context }: Route.LoaderArgs) => {
     fetchBoards({ baseUrl }),
     fetchClientConfig({ baseUrl }).catch(() => ({
       enable_user_registration: false,
+      enable_safe_mode: false,
     })),
   ]);
 
@@ -60,6 +61,7 @@ export const loader = async ({ params, context }: Route.LoaderArgs) => {
     {
       thread,
       boards,
+      enableSafeMode: clientConfig.enable_safe_mode ?? false,
       eddistData: {
         bbsName: context.BBS_NAME ?? "エッヂ掲示板",
         availableUserRegistration: clientConfig.enable_user_registration,
@@ -67,6 +69,7 @@ export const loader = async ({ params, context }: Route.LoaderArgs) => {
     } satisfies {
       thread: { threadName: string; responses: Response[] };
       boards: Board[];
+      enableSafeMode: boolean;
       eddistData: {
         bbsName: string;
         availableUserRegistration: boolean;
@@ -116,7 +119,9 @@ const Meta = ({ bbsName, threadName }: { bbsName: string; threadName: string }) 
   </>
 );
 
-const ThreadPage = ({ loaderData: { boards, thread, eddistData } }: Route.ComponentProps) => {
+const ThreadPage = ({
+  loaderData: { boards, thread, enableSafeMode, eddistData },
+}: Route.ComponentProps) => {
   const params = useParams();
 
   const [popups, setPopups] = useState<Popup[]>([]);
@@ -364,7 +369,11 @@ const ThreadPage = ({ loaderData: { boards, thread, eddistData } }: Route.Compon
 
         {hasEverOpenedNGSettings.current && (
           <Suspense fallback={null}>
-            <LazyNGWordsSettingsModal open={showNGSettings} setOpen={setShowNGSettings} />
+            <LazyNGWordsSettingsModal
+              open={showNGSettings}
+              setOpen={setShowNGSettings}
+              enableSafeMode={enableSafeMode}
+            />
           </Suspense>
         )}
       </header>

--- a/eddist-server/client-v2/app/utils/cookie.ts
+++ b/eddist-server/client-v2/app/utils/cookie.ts
@@ -1,0 +1,7 @@
+export const parseCookie = (cookieHeader: string, name: string): string | undefined => {
+  const entry = cookieHeader
+    .split(";")
+    .map((s) => s.trim())
+    .find((s) => s.startsWith(`${name}=`));
+  return entry?.slice(name.length + 1);
+};

--- a/eddist-server/src/app.rs
+++ b/eddist-server/src/app.rs
@@ -35,6 +35,7 @@ use crate::{
         dat_routing::{get_dat_txt, get_kako_dat_txt},
         notice::{get_latest_notices, get_notice_by_slug, get_notices_paginated},
         re_auth::{get_re_auth, post_re_auth},
+        safe_mode::get_unsafe_thread_ids,
         stats::get_stats,
         subject_list::{get_subject_txt, get_subject_txt_with_metadent},
         terms::get_terms,
@@ -64,6 +65,7 @@ pub struct AppState {
     pub stats_repo: StatsRepositoryImpl,
     pub template_engine: Arc<Handlebars<'static>>,
     pub tinker_secret: String,
+    pub redis_conn: redis::aio::ConnectionManager,
 }
 
 impl AppState {
@@ -110,6 +112,7 @@ async fn get_setting_txt(
                 max_response_body_lines,
                 ..
             },
+        ..
     }) = state
         .services
         .board_info()
@@ -255,6 +258,10 @@ pub fn create_app(app_state: AppState, conn_mgr: redis::aio::ConnectionManager) 
         .route("/api/notices/{slug}", get(get_notice_by_slug))
         .route("/api/client-config", get(get_api_client_config))
         .route("/api/stats", get(get_stats))
+        .route(
+            "/api/{boardKey}/unsafe-thread-ids",
+            get(get_unsafe_thread_ids),
+        )
         .nest("/user", user_routes())
         .route(
             "/{boardKey}",

--- a/eddist-server/src/app.rs
+++ b/eddist-server/src/app.rs
@@ -189,9 +189,11 @@ async fn get_api_boards(State(state): State<AppState>) -> impl IntoResponse {
 async fn get_api_client_config() -> impl IntoResponse {
     let enable_user_registration =
         get_server_setting_bool(ServerSettingKey::EnableIdpLinking).await;
+    let enable_safe_mode = get_server_setting_bool(ServerSettingKey::EnableSafeMode).await;
 
     let mut resp = Json(serde_json::json!({
         "enable_user_registration": enable_user_registration,
+        "enable_safe_mode": enable_safe_mode,
     }))
     .into_response();
     resp.headers_mut()

--- a/eddist-server/src/lib.rs
+++ b/eddist-server/src/lib.rs
@@ -54,6 +54,7 @@ mod routes {
     pub mod dat_routing;
     pub mod notice;
     pub mod re_auth;
+    pub mod safe_mode;
     pub mod stats;
     pub mod subject_list;
     pub mod terms;
@@ -128,6 +129,7 @@ pub fn create_test_app(
         tinker_secret: base64::engine::general_purpose::STANDARD
             .encode(Uuid::now_v7().as_bytes())
             .to_string(),
+        redis_conn: redis_conn.clone(),
     };
 
     // Use the actual create_app from app module

--- a/eddist-server/src/main.rs
+++ b/eddist-server/src/main.rs
@@ -132,6 +132,7 @@ async fn main() -> anyhow::Result<()> {
         stats_repo,
         template_engine: Arc::new(template_engine),
         tinker_secret,
+        redis_conn: conn_mgr.clone(),
     };
 
     // Start background task for user restriction cache refresh

--- a/eddist-server/src/routes/safe_mode.rs
+++ b/eddist-server/src/routes/safe_mode.rs
@@ -1,0 +1,60 @@
+use axum::{
+    Json,
+    body::Body,
+    extract::{Path, State},
+    response::{IntoResponse, Response},
+};
+use eddist_core::{domain::board::validate_board_key, redis_keys::unsafe_threads_key};
+use redis::AsyncCommands;
+use serde::Serialize;
+
+use crate::{
+    AppState,
+    services::{AppService, board_info_service::BoardInfoServiceInput},
+};
+
+#[derive(Serialize)]
+pub struct UnsafeThreadIdsResponse {
+    pub thread_ids: Vec<u64>,
+}
+
+pub async fn get_unsafe_thread_ids(
+    State(state): State<AppState>,
+    Path(board_key): Path<String>,
+) -> Response {
+    if validate_board_key(&board_key).is_err() {
+        return Response::builder().status(404).body(Body::empty()).unwrap();
+    }
+
+    let board_info = state
+        .get_container()
+        .board_info()
+        .execute(BoardInfoServiceInput { board_key })
+        .await;
+
+    let board_id = match board_info {
+        Ok(info) => info.board_id,
+        Err(e) => {
+            if e.to_string().contains("board not found") {
+                return Response::builder().status(404).body(Body::empty()).unwrap();
+            }
+            log::error!("Failed to get board info for safe mode: {e:?}");
+            return Response::builder().status(500).body(Body::empty()).unwrap();
+        }
+    };
+
+    let key = unsafe_threads_key(board_id);
+    let mut redis_conn = state.redis_conn.clone();
+    let thread_ids: Vec<u64> = match redis_conn.smembers(&key).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            log::error!("Failed to query unsafe threads from Redis: {e:?}");
+            vec![]
+        }
+    };
+
+    let mut resp = Json(UnsafeThreadIdsResponse { thread_ids }).into_response();
+    resp.headers_mut()
+        .insert("Cache-Control", "s-maxage=5, max-age=5".parse().unwrap());
+    resp
+}

--- a/eddist-server/src/routes/safe_mode.rs
+++ b/eddist-server/src/routes/safe_mode.rs
@@ -10,7 +10,11 @@ use serde::Serialize;
 
 use crate::{
     AppState,
-    services::{AppService, board_info_service::BoardInfoServiceInput},
+    services::{
+        AppService,
+        board_info_service::BoardInfoServiceInput,
+        server_settings_cache::{ServerSettingKey, get_server_setting_bool},
+    },
 };
 
 #[derive(Serialize)]
@@ -22,6 +26,10 @@ pub async fn get_unsafe_thread_ids(
     State(state): State<AppState>,
     Path(board_key): Path<String>,
 ) -> Response {
+    if !get_server_setting_bool(ServerSettingKey::EnableSafeMode).await {
+        return Response::builder().status(404).body(Body::empty()).unwrap();
+    }
+
     if validate_board_key(&board_key).is_err() {
         return Response::builder().status(404).body(Body::empty()).unwrap();
     }

--- a/eddist-server/src/services/board_info_service.rs
+++ b/eddist-server/src/services/board_info_service.rs
@@ -1,4 +1,5 @@
 use eddist_core::domain::board::BoardInfo;
+use uuid::Uuid;
 
 use crate::{domain, repositories::bbs_repository::BbsRepository};
 
@@ -29,6 +30,7 @@ impl<T: BbsRepository + Clone> AppService<BoardInfoServiceInput, BoardInfoServic
             .ok_or_else(|| anyhow::anyhow!("board not found"))?;
 
         Ok(BoardInfoServiceOutput {
+            board_id: board.id,
             board_key: board.board_key,
             name: board.name,
             default_name: board.default_name,
@@ -42,6 +44,7 @@ pub struct BoardInfoServiceInput {
 }
 
 pub struct BoardInfoServiceOutput {
+    pub board_id: Uuid,
     pub board_key: String,
     pub name: String,
     pub default_name: String,


### PR DESCRIPTION
- eddist-core: add unsafe_threads_key() Redis key constructor
- eddist-persistence: subscribe to CHANNEL_THREAD_CREATED; write flagged thread unix_time into Redis SADD bbs:safe_mode:unsafe_threads:{board_id}
- eddist-cron: remove stale unsafe thread IDs from Redis when threads are archived/inactivated
- eddist-server: add GET /{boardKey}/api/unsafe-thread-ids endpoint that reads the Redis set and returns thread IDs as JSON; add redis_conn to AppState; expose board_id from BoardInfoServiceOutput
- client-v2: detect safe mode via ?_v=full param or safe_mode cookie in SSR loader; fetch unsafe thread IDs and filter from thread list; add safe mode toggle tab to NG settings modal with cookie management
