### PR TITLE
feat: add trending now endpoint across all boards with OpenAI moderation support

### DIFF
--- a/.sqlx/query-3f507c28c5fb40236675f2134246642a2c5f5789325b26e032f079d4dabaa469.json
+++ b/.sqlx/query-3f507c28c5fb40236675f2134246642a2c5f5789325b26e032f079d4dabaa469.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "MySQL",
+  "query": "SELECT\n                BIN_TO_UUID(t.id)       AS \"thread_id!: String\",\n                BIN_TO_UUID(t.board_id) AS \"board_id!: String\",\n                b.board_key             AS board_key,\n                b.name                  AS board_name,\n                t.thread_number         AS thread_number,\n                t.title                 AS title,\n                t.response_count        AS response_count,\n                COUNT(r.id)             AS \"recent_response_count: i64\"\n            FROM threads t\n            INNER JOIN boards b ON b.id = t.board_id\n            INNER JOIN responses r\n                   ON r.thread_id = t.id\n                   AND r.created_at >= DATE_SUB(NOW(), INTERVAL ? HOUR)\n                   AND r.is_abone = FALSE\n            WHERE t.active   = TRUE\n              AND t.archived = FALSE\n            GROUP BY t.id, t.board_id, b.board_key, b.name, t.thread_number, t.title, t.response_count\n            ORDER BY COUNT(r.id) DESC\n            LIMIT ?",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "thread_id!: String",
+        "type_info": {
+          "type": "VarString",
+          "flags": "",
+          "max_size": 144
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "board_id!: String",
+        "type_info": {
+          "type": "VarString",
+          "flags": "",
+          "max_size": 144
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "board_key",
+        "type_info": {
+          "type": "VarString",
+          "flags": "NOT_NULL | UNIQUE_KEY | NO_DEFAULT_VALUE",
+          "max_size": 1020
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "board_name",
+        "type_info": {
+          "type": "VarString",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "max_size": 1020
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "thread_number",
+        "type_info": {
+          "type": "LongLong",
+          "flags": "NOT_NULL | MULTIPLE_KEY | NO_DEFAULT_VALUE",
+          "max_size": 20
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "title",
+        "type_info": {
+          "type": "Blob",
+          "flags": "NOT_NULL | BLOB | NO_DEFAULT_VALUE",
+          "max_size": 262140
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "response_count",
+        "type_info": {
+          "type": "Long",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "max_size": 11
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "recent_response_count: i64",
+        "type_info": {
+          "type": "LongLong",
+          "flags": "NOT_NULL | BINARY",
+          "max_size": 21
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3f507c28c5fb40236675f2134246642a2c5f5789325b26e032f079d4dabaa469"
+}

--- a/eddist-core/src/redis_keys.rs
+++ b/eddist-core/src/redis_keys.rs
@@ -75,6 +75,7 @@ pub fn unsafe_threads_key(board_id: impl std::fmt::Display) -> String {
 }
 
 pub const DB_FAILED_CACHE_RES_KEY: &str = "bbs:db_failed_cache:res";
+pub const TRENDING_THREADS_CACHE_KEY: &str = "bbs:trending_threads";
 
 pub const CHANNEL_RES_CREATED: &str = "bbs:event:res_created";
 pub const CHANNEL_THREAD_CREATED: &str = "bbs:event:thread_created";

--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -284,6 +284,16 @@ const ThreadListPage = ({
             className={twMerge("w-4 h-4", (isRefreshing || isPullRefreshing) && "animate-spin")}
           />
         </button>
+        {safeMode && (
+          <button
+            type="button"
+            onClick={openNGSettings}
+            className="hidden lg:flex px-2 py-1 mx-1 text-xs rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-700 items-center gap-1 cursor-pointer"
+            title="セーフモード有効 — クリックして設定"
+          >
+            セーフモード
+          </button>
+        )}
         <button
           type="button"
           onClick={openNGSettings}

--- a/eddist-server/src/app.rs
+++ b/eddist-server/src/app.rs
@@ -26,6 +26,7 @@ use crate::{
         notice_repository::NoticeRepositoryImpl,
         stats_repository::StatsRepositoryImpl,
         terms_repository::TermsRepositoryImpl,
+        trending_repository::TrendingRepositoryImpl,
         user_repository::UserRepositoryImpl,
         user_restriction_repository::UserRestrictionRepositoryImpl,
     },
@@ -39,6 +40,7 @@ use crate::{
         stats::get_stats,
         subject_list::{get_subject_txt, get_subject_txt_with_metadent},
         terms::get_terms,
+        trending::get_trending,
         user::user_routes,
     },
     services::server_settings_cache::{ServerSettingKey, get_server_setting_bool},
@@ -63,6 +65,7 @@ pub struct AppState {
     pub notice_repo: NoticeRepositoryImpl,
     pub terms_repo: TermsRepositoryImpl,
     pub stats_repo: StatsRepositoryImpl,
+    pub trending_repo: TrendingRepositoryImpl,
     pub template_engine: Arc<Handlebars<'static>>,
     pub tinker_secret: String,
     pub redis_conn: redis::aio::ConnectionManager,
@@ -260,6 +263,7 @@ pub fn create_app(app_state: AppState, conn_mgr: redis::aio::ConnectionManager) 
         .route("/api/notices/{slug}", get(get_notice_by_slug))
         .route("/api/client-config", get(get_api_client_config))
         .route("/api/stats", get(get_stats))
+        .route("/api/trending", get(get_trending))
         .route(
             "/api/{boardKey}/unsafe-thread-ids",
             get(get_unsafe_thread_ids),

--- a/eddist-server/src/lib.rs
+++ b/eddist-server/src/lib.rs
@@ -14,6 +14,7 @@ pub mod repositories {
     pub mod notice_repository;
     pub mod stats_repository;
     pub mod terms_repository;
+    pub mod trending_repository;
     pub mod user_repository;
     pub mod user_restriction_repository;
 }
@@ -58,6 +59,7 @@ mod routes {
     pub mod stats;
     pub mod subject_list;
     pub mod terms;
+    pub mod trending;
     pub mod user;
 }
 
@@ -103,6 +105,8 @@ pub fn create_test_app(
     let notice_repo = NoticeRepositoryImpl::new(pool.clone());
     let terms_repo = crate::repositories::terms_repository::TermsRepositoryImpl::new(pool.clone());
     let stats_repo = crate::repositories::stats_repository::StatsRepositoryImpl::new(pool.clone());
+    let trending_repo =
+        crate::repositories::trending_repository::TrendingRepositoryImpl::new(pool.clone());
 
     drop(refresh_server_settings_cache(&pool));
     start_captcha_config_refresh_task(pool.clone(), std::time::Duration::from_secs(300));
@@ -125,6 +129,7 @@ pub fn create_test_app(
         notice_repo,
         terms_repo,
         stats_repo,
+        trending_repo,
         template_engine: std::sync::Arc::new(load_template_engine()),
         tinker_secret: base64::engine::general_purpose::STANDARD
             .encode(Uuid::now_v7().as_bytes())

--- a/eddist-server/src/main.rs
+++ b/eddist-server/src/main.rs
@@ -18,6 +18,7 @@ use eddist::{
         notice_repository::NoticeRepositoryImpl,
         stats_repository::StatsRepositoryImpl,
         terms_repository::TermsRepositoryImpl,
+        trending_repository::TrendingRepositoryImpl,
         user_repository::UserRepositoryImpl,
         user_restriction_repository::UserRestrictionRepositoryImpl,
     },
@@ -109,6 +110,7 @@ async fn main() -> anyhow::Result<()> {
     let stats_repo = StatsRepositoryImpl::new(pool.clone());
     let stats_repo_for_flush = stats_repo.clone();
     let stats_repo_for_shutdown = stats_repo.clone();
+    let trending_repo = TrendingRepositoryImpl::new(pool.clone());
 
     // Load initial server settings from database and initialize cache
     refresh_server_settings_cache(&pool).await?;
@@ -130,6 +132,7 @@ async fn main() -> anyhow::Result<()> {
         notice_repo,
         terms_repo,
         stats_repo,
+        trending_repo,
         template_engine: Arc::new(template_engine),
         tinker_secret,
         redis_conn: conn_mgr.clone(),

--- a/eddist-server/src/repositories/trending_repository.rs
+++ b/eddist-server/src/repositories/trending_repository.rs
@@ -1,0 +1,72 @@
+use sqlx::MySqlPool;
+
+#[derive(Debug, Clone)]
+pub struct TrendingThread {
+    pub thread_id: String,
+    pub board_id: String,
+    pub board_key: String,
+    pub board_name: String,
+    pub thread_number: i64,
+    pub title: String,
+    pub response_count: i32,
+    pub recent_response_count: i64,
+}
+
+#[async_trait::async_trait]
+pub trait TrendingRepository: Send + Sync + 'static {
+    async fn get_trending_threads(
+        &self,
+        window_hours: u32,
+        fetch_limit: u32,
+    ) -> anyhow::Result<Vec<TrendingThread>>;
+}
+
+#[derive(Debug, Clone)]
+pub struct TrendingRepositoryImpl {
+    pool: MySqlPool,
+}
+
+impl TrendingRepositoryImpl {
+    pub fn new(pool: MySqlPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl TrendingRepository for TrendingRepositoryImpl {
+    async fn get_trending_threads(
+        &self,
+        window_hours: u32,
+        fetch_limit: u32,
+    ) -> anyhow::Result<Vec<TrendingThread>> {
+        let rows = sqlx::query_as!(
+            TrendingThread,
+            r#"SELECT
+                BIN_TO_UUID(t.id)       AS "thread_id!: String",
+                BIN_TO_UUID(t.board_id) AS "board_id!: String",
+                b.board_key             AS board_key,
+                b.name                  AS board_name,
+                t.thread_number         AS thread_number,
+                t.title                 AS title,
+                t.response_count        AS response_count,
+                COUNT(r.id)             AS "recent_response_count: i64"
+            FROM threads t
+            INNER JOIN boards b ON b.id = t.board_id
+            INNER JOIN responses r
+                   ON r.thread_id = t.id
+                   AND r.created_at >= DATE_SUB(NOW(), INTERVAL ? HOUR)
+                   AND r.is_abone = FALSE
+            WHERE t.active   = TRUE
+              AND t.archived = FALSE
+            GROUP BY t.id, t.board_id, b.board_key, b.name, t.thread_number, t.title, t.response_count
+            ORDER BY COUNT(r.id) DESC
+            LIMIT ?"#,
+            window_hours,
+            fetch_limit,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+}

--- a/eddist-server/src/routes/trending.rs
+++ b/eddist-server/src/routes/trending.rs
@@ -1,0 +1,116 @@
+use std::collections::{HashMap, HashSet};
+
+use axum::{Json, extract::State, http::HeaderValue, response::IntoResponse};
+use eddist_core::redis_keys::{TRENDING_THREADS_CACHE_KEY, unsafe_threads_key};
+use http::StatusCode;
+use redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AppState,
+    repositories::trending_repository::TrendingRepository,
+    services::server_settings_cache::{ServerSettingKey, get_server_setting_bool},
+};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TrendingThreadResponse {
+    pub board_key: String,
+    pub board_name: String,
+    pub thread_number: i64,
+    pub title: String,
+    pub response_count: i32,
+    pub recent_response_count: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TrendingResponse {
+    pub threads: Vec<TrendingThreadResponse>,
+}
+
+pub async fn get_trending(State(state): State<AppState>) -> impl IntoResponse {
+    let mut redis_conn = state.redis_conn.clone();
+
+    if let Ok(cached) = redis_conn
+        .get::<_, Option<String>>(TRENDING_THREADS_CACHE_KEY)
+        .await
+    {
+        if let Some(json) = cached {
+            if let Ok(threads) = serde_json::from_str::<Vec<TrendingThreadResponse>>(&json) {
+                let mut resp = Json(TrendingResponse { threads }).into_response();
+                resp.headers_mut()
+                    .insert("Cache-Control", HeaderValue::from_static("s-maxage=60"));
+                return resp;
+            }
+        }
+    }
+
+    let exclude_flagged = get_server_setting_bool(ServerSettingKey::AiModerationOnRes).await
+        || get_server_setting_bool(ServerSettingKey::AiModerationOnThread).await;
+
+    let candidates = match state.trending_repo.get_trending_threads(6, 20).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Failed to fetch trending threads: {e:?}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response();
+        }
+    };
+
+    let threads = if exclude_flagged {
+        let board_ids: Vec<String> = candidates
+            .iter()
+            .map(|t| t.board_id.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        let mut unsafe_by_board: HashMap<String, HashSet<i64>> = HashMap::new();
+        for board_id in board_ids {
+            let key = unsafe_threads_key(&board_id);
+            let unsafe_ids: Vec<i64> = redis_conn.smembers(&key).await.unwrap_or_default();
+            unsafe_by_board.insert(board_id, unsafe_ids.into_iter().collect());
+        }
+
+        candidates
+            .into_iter()
+            .filter(|t| {
+                unsafe_by_board
+                    .get(&t.board_id)
+                    .map(|set| !set.contains(&t.thread_number))
+                    .unwrap_or(true)
+            })
+            .take(10)
+            .map(|t| TrendingThreadResponse {
+                board_key: t.board_key,
+                board_name: t.board_name,
+                thread_number: t.thread_number,
+                title: t.title,
+                response_count: t.response_count,
+                recent_response_count: t.recent_response_count,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        candidates
+            .into_iter()
+            .take(10)
+            .map(|t| TrendingThreadResponse {
+                board_key: t.board_key,
+                board_name: t.board_name,
+                thread_number: t.thread_number,
+                title: t.title,
+                response_count: t.response_count,
+                recent_response_count: t.recent_response_count,
+            })
+            .collect::<Vec<_>>()
+    };
+
+    if let Ok(serialized) = serde_json::to_string(&threads) {
+        let _ = redis_conn
+            .set_ex::<_, _, ()>(TRENDING_THREADS_CACHE_KEY, serialized, 300)
+            .await;
+    }
+
+    let mut resp = Json(TrendingResponse { threads }).into_response();
+    resp.headers_mut()
+        .insert("Cache-Control", HeaderValue::from_static("s-maxage=60"));
+    resp
+}


### PR DESCRIPTION
- Add trending_repository.rs with get_trending_threads() query that fetches threads with highest response count in the last 6 hours
- Add trending.rs route handler (GET /api/trending) returning top 10 threads across all boards, filtered to exclude OpenAI-flagged threads when moderation is active
- Cache trending results in Redis with 5-minute TTL
- Integrate TrendingRepositoryImpl into AppState and wire it in main.rs
- Add TRENDING_THREADS_CACHE_KEY to redis_keys constants