### PR TITLE
refactor: consolidate patterns in eddist-admin-client

### DIFF
--- a/eddist-admin/client/app/components/BoardMultiSelect.tsx
+++ b/eddist-admin/client/app/components/BoardMultiSelect.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+import {
+  type Control,
+  Controller,
+  type FieldValues,
+  type Path,
+  type PathValue,
+} from "react-hook-form";
+import Select from "react-select";
+import { getBoards } from "~/hooks/queries";
+
+interface BoardOption {
+  label: string;
+  value: string;
+}
+
+interface BoardMultiSelectProps<TFieldValues extends FieldValues> {
+  control: Control<TFieldValues>;
+  name: Path<TFieldValues>;
+  defaultBoardIds: string[];
+}
+
+function BoardMultiSelect<TFieldValues extends FieldValues>({
+  control,
+  name,
+  defaultBoardIds,
+}: BoardMultiSelectProps<TFieldValues>) {
+  const { data: boards } = getBoards({});
+
+  const boardOptions = useMemo<BoardOption[]>(
+    () => boards?.map((b) => ({ label: b.board_key, value: b.id })) ?? [],
+    [boards],
+  );
+
+  const defaultValue = useMemo<BoardOption[]>(
+    () =>
+      defaultBoardIds
+        .map((id) => {
+          const board = boards?.find((b) => b.id === id);
+          return board ? { label: board.board_key, value: board.id } : null;
+        })
+        .filter((v): v is BoardOption => v !== null),
+    [defaultBoardIds, boards],
+  );
+
+  return (
+    <div className="mt-4">
+      <span>Boards</span>
+      <Controller
+        name={name}
+        control={control}
+        defaultValue={defaultValue as PathValue<TFieldValues, Path<TFieldValues>>}
+        render={({ field }) => (
+          <Select
+            options={boardOptions}
+            value={boardOptions.filter((opt) =>
+              field.value?.some((v: BoardOption) => v.value === opt.value),
+            )}
+            onChange={(value) => field.onChange(value)}
+            isMulti
+          />
+        )}
+      />
+    </div>
+  );
+}
+
+export default BoardMultiSelect;

--- a/eddist-admin/client/app/components/CreateCapModal.tsx
+++ b/eddist-admin/client/app/components/CreateCapModal.tsx
@@ -5,10 +5,9 @@ import { useCreateCap } from "~/hooks/queries";
 interface CreateCapModalProps {
   open: boolean;
   setOpen: (open: boolean) => void;
-  refetch: () => Promise<unknown>;
 }
 
-const CreateCapModal = ({ setOpen, refetch, open }: CreateCapModalProps) => {
+const CreateCapModal = ({ setOpen, open }: CreateCapModalProps) => {
   const { register, handleSubmit, reset } = useForm();
 
   const createCapMutation = useCreateCap();
@@ -38,7 +37,6 @@ const CreateCapModal = ({ setOpen, refetch, open }: CreateCapModalProps) => {
                 {
                   onSuccess: () => {
                     setOpen(false);
-                    refetch();
                   },
                 },
               );

--- a/eddist-admin/client/app/components/CreateNgWordModal.tsx
+++ b/eddist-admin/client/app/components/CreateNgWordModal.tsx
@@ -5,10 +5,9 @@ import { useCreateNgWord } from "~/hooks/queries";
 interface CreateNgWordModalProps {
   open: boolean;
   setOpen: (open: boolean) => void;
-  refetch: () => Promise<unknown>;
 }
 
-const CreateNgWordModal = ({ setOpen, refetch, open }: CreateNgWordModalProps) => {
+const CreateNgWordModal = ({ setOpen, open }: CreateNgWordModalProps) => {
   const { register, handleSubmit } = useForm();
 
   const createNgWordMutation = useCreateNgWord();
@@ -30,7 +29,6 @@ const CreateNgWordModal = ({ setOpen, refetch, open }: CreateNgWordModalProps) =
                 {
                   onSuccess: () => {
                     setOpen(false);
-                    refetch();
                   },
                 },
               );

--- a/eddist-admin/client/app/components/EditCapModal.tsx
+++ b/eddist-admin/client/app/components/EditCapModal.tsx
@@ -1,36 +1,17 @@
 import { Button, Label, Modal, ModalBody, ModalHeader, TextInput } from "flowbite-react";
-import { useMemo } from "react";
-import { Controller, useForm } from "react-hook-form";
-import Select from "react-select";
-import { getBoards, useUpdateCap } from "~/hooks/queries";
-import type { Cap } from "~/routes/dashboard.caps";
+import { useForm } from "react-hook-form";
+import BoardMultiSelect from "~/components/BoardMultiSelect";
+import { useUpdateCap } from "~/hooks/queries";
+import type { Cap } from "~/types/entities";
 
 interface EditCapModalProps {
   open: boolean;
   selectedCap: Cap;
   setOpen: (open: boolean) => void;
-  refetch: () => Promise<unknown>;
 }
 
-interface BoardSelectOption {
-  label: string;
-  value: string;
-}
-
-const EditCapModal = ({ open, selectedCap, setOpen, refetch }: EditCapModalProps) => {
+const EditCapModal = ({ open, selectedCap, setOpen }: EditCapModalProps) => {
   const { register, handleSubmit, control, reset } = useForm();
-
-  const { data: boards } = getBoards({});
-  const boardSelectOptions = useMemo(() => {
-    if (boards) {
-      return boards.map((board) => ({
-        label: board.board_key,
-        value: board.board_key,
-      }));
-    }
-    return [];
-  }, [boards]);
-
   const updateCapMutation = useUpdateCap();
 
   return (
@@ -46,10 +27,7 @@ const EditCapModal = ({ open, selectedCap, setOpen, refetch }: EditCapModalProps
       <ModalBody>
         <form
           onSubmit={handleSubmit((data) => {
-            const boardIds = data.boardKeys.map(
-              (val: BoardSelectOption) =>
-                boards?.find((board) => board.board_key === val.value)?.id,
-            );
+            const boardIds = data.boardKeys.map((v: { value: string }) => v.value);
             const password = data.password ? data.password : undefined;
 
             updateCapMutation.mutate(
@@ -70,7 +48,6 @@ const EditCapModal = ({ open, selectedCap, setOpen, refetch }: EditCapModalProps
                 onSuccess: () => {
                   setOpen(false);
                   reset();
-                  refetch();
                 },
               },
             );
@@ -82,9 +59,7 @@ const EditCapModal = ({ open, selectedCap, setOpen, refetch }: EditCapModalProps
               placeholder="Name..."
               required
               defaultValue={selectedCap.name}
-              {...register("name", {
-                required: true,
-              })}
+              {...register("name", { required: true })}
             />
           </div>
           <div className="flex flex-col mt-4">
@@ -92,52 +67,18 @@ const EditCapModal = ({ open, selectedCap, setOpen, refetch }: EditCapModalProps
             <TextInput
               placeholder="Description..."
               defaultValue={selectedCap.description}
-              {...register("description", {
-                required: false,
-              })}
+              {...register("description")}
             />
           </div>
           <div className="flex flex-col mt-4">
             <Label>Password</Label>
-            <TextInput
-              placeholder="Password..."
-              type="password"
-              {...register("password", {
-                required: false,
-              })}
-            />
+            <TextInput placeholder="Password..." type="password" {...register("password")} />
           </div>
-          <div>
-            Boards
-            <Controller
-              name="boardKeys"
-              control={control}
-              defaultValue={selectedCap?.boardIds.map((boardId) => {
-                const board = boards?.find((b) => b.id === boardId);
-                return {
-                  label: board?.board_key,
-                  value: board?.board_key,
-                };
-              })}
-              render={({ field }) => (
-                <Select
-                  options={boardSelectOptions}
-                  value={boardSelectOptions
-                    .map((board) => {
-                      if (field.value?.find((v: BoardSelectOption) => v.value === board.value)) {
-                        return board;
-                      }
-                      return null;
-                    })
-                    .filter((board) => board != null)}
-                  onChange={(value) => {
-                    field.onChange(value);
-                  }}
-                  isMulti
-                />
-              )}
-            />
-          </div>
+          <BoardMultiSelect
+            control={control}
+            name="boardKeys"
+            defaultBoardIds={selectedCap.boardIds}
+          />
           <div className="flex justify-end mt-4">
             <Button type="submit">Submit</Button>
           </div>

--- a/eddist-admin/client/app/hooks/queries/caps.ts
+++ b/eddist-admin/client/app/hooks/queries/caps.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-q
 import { toast } from "react-toastify";
 import client from "~/openapi/client";
 import type { paths } from "~/openapi/schema";
+import { sortById } from "~/utils/sort";
 import type { UseQueryOptions } from "./types";
 
 const GET_CAPS = "/caps/";
@@ -15,19 +16,7 @@ export const getCaps = ({ params }: UseQueryOptions<paths[typeof GET_CAPS]["get"
         signal,
       });
 
-      if (data) {
-        data.sort((a, b) => {
-          if (a.id < b.id) {
-            return -1;
-          }
-          if (a.id > b.id) {
-            return 1;
-          }
-          return 0;
-        });
-      }
-
-      return data;
+      return data ? sortById(data) : data;
     },
   });
 };

--- a/eddist-admin/client/app/hooks/queries/ng-words.ts
+++ b/eddist-admin/client/app/hooks/queries/ng-words.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-q
 import { toast } from "react-toastify";
 import client from "~/openapi/client";
 import type { paths } from "~/openapi/schema";
+import { sortById } from "~/utils/sort";
 import type { UseQueryOptions } from "./types";
 
 const GET_NG_WORDS = "/ng_words/";
@@ -15,19 +16,7 @@ export const getNgWords = ({ params }: UseQueryOptions<paths[typeof GET_NG_WORDS
         signal,
       });
 
-      if (data) {
-        data.sort((a, b) => {
-          if (a.id < b.id) {
-            return -1;
-          }
-          if (a.id > b.id) {
-            return 1;
-          }
-          return 0;
-        });
-      }
-
-      return data;
+      return data ? sortById(data) : data;
     },
   });
 };

--- a/eddist-admin/client/app/routes/dashboard.caps.tsx
+++ b/eddist-admin/client/app/routes/dashboard.caps.tsx
@@ -14,18 +14,11 @@ import CreateCapModal from "~/components/CreateCapModal";
 import EditCapModal from "~/components/EditCapModal";
 import { getCaps, useDeleteCap } from "~/hooks/queries";
 import { useCrudModalState } from "~/hooks/useCrudModalState";
+import type { Cap } from "~/types/entities";
 import { formatDateTime } from "~/utils/format";
 
-export interface Cap {
-  id: string;
-  name: string;
-  description: string;
-  password?: string;
-  boardIds: string[];
-}
-
 const CapPage = () => {
-  const { data: caps, refetch } = getCaps({});
+  const { data: caps } = getCaps({});
   const deleteMutation = useDeleteCap();
 
   const modal = useCrudModalState<Cap>();
@@ -37,7 +30,6 @@ const CapPage = () => {
         setOpen={(v) => {
           if (!v) modal.closeCreate();
         }}
-        refetch={refetch}
       />
 
       {modal.editingItem && (
@@ -47,7 +39,6 @@ const CapPage = () => {
           setOpen={(v) => {
             if (!v) modal.closeEdit();
           }}
-          refetch={refetch}
         />
       )}
 

--- a/eddist-admin/client/app/routes/dashboard.ngwords.tsx
+++ b/eddist-admin/client/app/routes/dashboard.ngwords.tsx
@@ -14,44 +14,21 @@ import {
   TableRow,
   TextInput,
 } from "flowbite-react";
-import { useMemo } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { BiDotsHorizontalRounded } from "react-icons/bi";
 import { FaPlus } from "react-icons/fa";
-import Select from "react-select";
+import BoardMultiSelect from "~/components/BoardMultiSelect";
 import CreateNgWordModal from "~/components/CreateNgWordModal";
-import { getBoards, getNgWords, useDeleteNgWord, useUpdateNgWord } from "~/hooks/queries";
+import { getNgWords, useDeleteNgWord, useUpdateNgWord } from "~/hooks/queries";
 import { useCrudModalState } from "~/hooks/useCrudModalState";
-
-interface NgWord {
-  id: string;
-  name: string;
-  word: string;
-  boardIds: string[];
-}
-
-interface BoardSelectOption {
-  label: string;
-  value: string;
-}
+import type { NgWord } from "~/types/entities";
 
 const NgWords = () => {
-  const { data: ngWords, refetch } = getNgWords({});
+  const { data: ngWords } = getNgWords({});
   const updateMutation = useUpdateNgWord();
   const deleteMutation = useDeleteNgWord();
   const modal = useCrudModalState<NgWord>();
   const { register, handleSubmit, control, reset } = useForm();
-
-  const { data: boards } = getBoards({});
-  const boardSelectOptions = useMemo(() => {
-    if (boards) {
-      return boards.map((board) => ({
-        label: board.board_key,
-        value: board.board_key,
-      }));
-    }
-    return [];
-  }, [boards]);
 
   return (
     <>
@@ -60,7 +37,6 @@ const NgWords = () => {
         setOpen={(v) => {
           if (!v) modal.closeCreate();
         }}
-        refetch={refetch}
       />
       <Modal
         show={modal.isEditOpen}
@@ -74,12 +50,7 @@ const NgWords = () => {
         <ModalBody>
           <form
             onSubmit={handleSubmit((data) => {
-              console.log(data);
-              const boardIds = data.boardKeys.map(
-                (val: BoardSelectOption) =>
-                  boards?.find((board) => board.board_key === val.value)?.id,
-              );
-              console.log(boardIds);
+              const boardIds = data.boardKeys.map((v: { value: string }) => v.value);
 
               updateMutation.mutate(
                 {
@@ -104,15 +75,12 @@ const NgWords = () => {
             })}
           >
             <div className="flex flex-col">
-              <input type="hidden" {...register("id")} value={modal.editingItem?.id} />
               <Label>Name</Label>
               <TextInput
                 placeholder="Name..."
                 required
                 defaultValue={modal.editingItem?.name}
-                {...register("name", {
-                  required: true,
-                })}
+                {...register("name", { required: true })}
               />
             </div>
             <div className="flex flex-col mt-4">
@@ -121,42 +89,14 @@ const NgWords = () => {
                 placeholder="Word..."
                 defaultValue={modal.editingItem?.word}
                 required
-                {...register("word", {
-                  required: true,
-                })}
+                {...register("word", { required: true })}
               />
             </div>
-            <div>
-              Boards
-              <Controller
-                name="boardKeys"
-                control={control}
-                defaultValue={modal.editingItem?.boardIds.map((boardId) => {
-                  const board = boards?.find((b) => b.id === boardId);
-                  return {
-                    label: board?.board_key,
-                    value: board?.board_key,
-                  };
-                })}
-                render={({ field }) => (
-                  <Select
-                    options={boardSelectOptions}
-                    value={boardSelectOptions
-                      .map((board) => {
-                        if (field.value?.find((v: BoardSelectOption) => v.value === board.value)) {
-                          return board;
-                        }
-                        return null;
-                      })
-                      .filter((board) => board != null)}
-                    onChange={(value) => {
-                      field.onChange(value);
-                    }}
-                    isMulti
-                  />
-                )}
-              />
-            </div>
+            <BoardMultiSelect
+              control={control}
+              name="boardKeys"
+              defaultBoardIds={modal.editingItem?.boardIds ?? []}
+            />
             <Button type="submit" className="mt-4">
               Submit
             </Button>

--- a/eddist-admin/client/app/routes/dashboard.tsx
+++ b/eddist-admin/client/app/routes/dashboard.tsx
@@ -39,7 +39,6 @@ const Hamburger = () => (
 
 const Layout: React.FC = () => {
   const location = useLocation();
-  const navBarSection = location.pathname.split("/")[2];
   const [isNavbarOpen, setIsNavbarOpen] = useState(false);
 
   return (
@@ -57,7 +56,9 @@ const Layout: React.FC = () => {
               to={`/dashboard/${item.kind}`}
               className={twMerge(
                 "flex items-center py-2 px-8 hover:bg-gray-700",
-                navBarSection === item.kind ? "bg-gray-900 text-gray-400" : "text-gray-400",
+                location.pathname.startsWith(`/dashboard/${item.kind}`)
+                  ? "bg-gray-900 text-gray-400"
+                  : "text-gray-400",
               )}
             >
               <Hamburger />

--- a/eddist-admin/client/app/types/entities.ts
+++ b/eddist-admin/client/app/types/entities.ts
@@ -1,0 +1,14 @@
+export interface Cap {
+  id: string;
+  name: string;
+  description: string;
+  password?: string;
+  boardIds: string[];
+}
+
+export interface NgWord {
+  id: string;
+  name: string;
+  word: string;
+  boardIds: string[];
+}

--- a/eddist-admin/client/app/utils/sort.ts
+++ b/eddist-admin/client/app/utils/sort.ts
@@ -1,0 +1,3 @@
+export function sortById<T extends { id: string }>(arr: T[]): T[] {
+  return [...arr].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}


### PR DESCRIPTION
- Extract BoardMultiSelect component to eliminate duplicate board selection logic
- Move Cap and NgWord types to ~/types/entities for reuse and decoupling
- Add sortById utility and apply across caps/ng-words query hooks
- Remove redundant refetch callbacks (mutations already invalidate queries)
- Fix fragile nav active state detection (split('/')[2] → startsWith)
- Remove debug console.logs and dead code from dashboard.ngwords