### PR TITLE
refactor: prepare eddist-admin for audit log and RBAC

### DIFF
--- a/eddist-admin/src/auth.rs
+++ b/eddist-admin/src/auth.rs
@@ -15,7 +15,6 @@ use oauth2::{
 };
 use serde::{Deserialize, Serialize};
 use tower_sessions::Session;
-use tracing::info_span;
 
 use crate::{
     AppState,
@@ -82,18 +81,18 @@ pub async fn verify_access_token(
                     .send()
                     .await
                     .map_err(|e| {
-                        log::error!("failed to fetch userinfo: {e:?}");
+                        tracing::error!("failed to fetch userinfo: {e:?}");
                         ErrorKind::InvalidToken
                     })?;
                 let text = res.text().await.map_err(|e| {
-                    log::error!("failed to read userinfo response: {e:?}");
+                    tracing::error!("failed to read userinfo response: {e:?}");
                     ErrorKind::InvalidToken
                 })?;
                 let res = serde_json::from_str::<Auth0UserInfo>(&text);
 
                 let info = match res {
                     Err(e) => {
-                        log::error!("failed to get userinfo: {e:?}");
+                        tracing::error!("failed to get userinfo: {e:?}");
                         return Err(ErrorKind::ExpiredSignature);
                     }
                     Ok(info) => info,
@@ -108,7 +107,7 @@ pub async fn verify_access_token(
                 })
             }
             Err(e) => {
-                log::error!("failed to verify access token: {e:?}");
+                tracing::error!("failed to verify access token: {e:?}");
                 Err(e.kind().clone())
             }
         }
@@ -125,7 +124,7 @@ pub async fn verify_access_token(
         match token {
             Ok(t) => Ok(t.claims),
             Err(e) => {
-                log::error!("failed to verify access token: {e:?}");
+                tracing::error!("failed to verify access token: {e:?}");
                 Err(e.kind().clone())
             }
         }
@@ -145,7 +144,7 @@ pub async fn auth_simple_header(
     if let Some(userinfo) = admin_session.userinfo
         && admin_session.next_refresh_at > Utc::now()
     {
-        log::info!("no need to retrieve userinfo");
+        tracing::info!("no need to retrieve userinfo");
         req.extensions_mut().insert(userinfo);
         return next.run(req).await;
     }
@@ -166,7 +165,7 @@ pub async fn auth_simple_header(
                     ..admin_session
                 };
                 if let Err(e) = session.insert("data", new_session).await {
-                    log::error!("failed to insert session: {e:?}");
+                    tracing::error!("failed to insert session: {e:?}");
                     return Response::builder()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
                         .body(Body::empty())
@@ -212,17 +211,17 @@ pub async fn auth_simple_header(
                             ..admin_session
                         };
                         if let Err(e) = session.insert("data", new_session).await {
-                            log::error!("failed to insert session: {e:?}");
+                            tracing::error!("failed to insert session: {e:?}");
                             return Response::builder()
                                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                                 .body(Body::empty())
                                 .unwrap();
                         }
-                        log::info!("success to verify access token from refresh token");
+                        tracing::info!("success to verify access token from refresh token");
                         userinfo
                     }
                     Err(e) => {
-                        info_span!("failed to verify access token", error = ?e);
+                        tracing::warn!(error = ?e, "failed to verify access token");
                         return Response::builder()
                             .status(StatusCode::UNAUTHORIZED)
                             .body(Body::empty())
@@ -231,7 +230,7 @@ pub async fn auth_simple_header(
                 }
             }
             Err(e) => {
-                log::error!("unexpected token verification error: {e:?}");
+                tracing::error!("unexpected token verification error: {e:?}");
                 return Response::builder()
                     .status(StatusCode::UNAUTHORIZED)
                     .body(Body::empty())
@@ -284,8 +283,12 @@ impl AdminSession {
         }
     }
 
-    pub fn get_admin_email(&self) -> Option<String> {
-        self.userinfo.as_ref().map(|info| info.email.clone())
+    pub fn get_admin_identity(&self) -> Option<AdminIdentity> {
+        self.userinfo.as_ref().map(|info| AdminIdentity {
+            sub: info.sub.clone(),
+            email: info.email.clone(),
+            username: info.preferred_username.clone(),
+        })
     }
 }
 
@@ -352,7 +355,7 @@ pub async fn get_login_callback(
 ) -> impl IntoResponse {
     let oauth_session = session.remove::<OAuthSession>("oauth").await;
     let Some(oauth_session) = oauth_session.ok().flatten() else {
-        info_span!("oauth_session is not found");
+        tracing::warn!("oauth_session is not found");
 
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -364,9 +367,10 @@ pub async fn get_login_callback(
     let csrf_state = CsrfToken::new(query.state.clone());
 
     if csrf_state.secret() != oauth_session.csrf_state.secret() {
-        info_span!("csrf_state is not matched",
-          server_state = ?oauth_session.csrf_state.secret(),
-          client_state = ?csrf_state.secret()
+        tracing::warn!(
+            server_state = ?oauth_session.csrf_state.secret(),
+            client_state = ?csrf_state.secret(),
+            "csrf_state is not matched"
         );
 
         return Response::builder()
@@ -389,14 +393,14 @@ pub async fn get_login_callback(
                 ..admin_session
             };
 
-            log::info!("success to get token from auth server");
+            tracing::info!("success to get token from auth server");
 
             let _ = session.insert("data", new_session).await;
 
             Redirect::to("/dashboard").into_response()
         }
         Err(e) => {
-            info_span!("failed to get token from auth server", error = ?e);
+            tracing::error!(error = ?e, "failed to get token from auth server");
 
             Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
@@ -438,10 +442,13 @@ where
     }
 }
 
-/// Extractor that pulls admin email from the session, returning 401 if not authenticated.
-pub struct AdminEmail(pub String);
+pub struct AdminIdentity {
+    pub sub: String,
+    pub email: String,
+    pub username: String,
+}
 
-impl<S> FromRequestParts<S> for AdminEmail
+impl<S> FromRequestParts<S> for AdminIdentity
 where
     S: Send + Sync,
 {
@@ -450,8 +457,7 @@ where
     async fn from_request_parts(req: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let session = AdminSession::from_request_parts(req, state).await?;
         session
-            .get_admin_email()
-            .map(AdminEmail)
+            .get_admin_identity()
             .ok_or((StatusCode::UNAUTHORIZED, "No user information available"))
     }
 }
@@ -489,7 +495,7 @@ pub async fn post_native_session(
     let user_info = match verify_access_token(&req.access_token, true).await {
         Ok(token) => token,
         Err(e) => {
-            info_span!("failed to verify access token for native session", error = ?e);
+            tracing::warn!(error = ?e, "failed to verify access token for native session");
             return Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
                 .header("Content-Type", "application/json")
@@ -519,7 +525,7 @@ pub async fn post_native_session(
     // Store the session
     let session_id = uuid::Uuid::from_bytes(admin_session.id).to_string();
     if let Err(e) = session.insert("data", admin_session).await {
-        log::error!("failed to insert native session: {e:?}");
+        tracing::error!("failed to insert native session: {e:?}");
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .header("Content-Type", "application/json")

--- a/eddist-admin/src/main.rs
+++ b/eddist-admin/src/main.rs
@@ -48,6 +48,8 @@ mod api_doc;
 mod auth;
 pub(crate) mod error;
 mod models;
+mod services;
+pub(crate) mod utils;
 mod repository {
     pub mod admin_archive_repository;
     pub mod admin_bbs_repository;
@@ -129,6 +131,35 @@ async fn internal_secret_auth(
     next.run(req).await
 }
 
+/// Repositories for content management (boards, threads, responses, S3 archives).
+#[derive(Clone)]
+pub(crate) struct ContentRepos {
+    pub board: Arc<dyn AdminBoardRepository>,
+    pub thread: Arc<dyn AdminThreadRepository>,
+    pub response: Arc<dyn AdminResponseRepository>,
+    pub archive: Arc<dyn AdminArchiveRepository>,
+}
+
+/// Repositories for moderation (NG words, caps, user restrictions, authed tokens).
+#[derive(Clone)]
+pub(crate) struct ModerationRepos {
+    pub ng_word: Arc<dyn NgWordRepository>,
+    pub cap: Arc<dyn CapRepository>,
+    pub user_restriction: Arc<dyn UserRestrictionRepository>,
+    pub authed_token: Arc<dyn AuthedTokenRepository>,
+}
+
+/// Repositories for site administration (users, IdPs, notices, terms, captcha, settings).
+#[derive(Clone)]
+pub(crate) struct AdminRepos {
+    pub user: Arc<dyn AdminUserRepository>,
+    pub idp: Arc<dyn IdpAdminRepository>,
+    pub notice: Arc<dyn NoticeRepository>,
+    pub terms: Arc<dyn TermsRepository>,
+    pub captcha_config: Arc<dyn CaptchaConfigRepository>,
+    pub server_settings: Arc<dyn ServerSettingsRepository>,
+}
+
 #[derive(Clone)]
 pub(crate) struct AppState {
     pub oauth2_client: oauth2::basic::BasicClient<
@@ -138,21 +169,7 @@ pub(crate) struct AppState {
         EndpointNotSet,
         EndpointSet,
     >,
-    pub admin_board_repo: Arc<dyn AdminBoardRepository>,
-    pub admin_thread_repo: Arc<dyn AdminThreadRepository>,
-    pub admin_response_repo: Arc<dyn AdminResponseRepository>,
-    pub ng_word_repo: Arc<dyn NgWordRepository>,
-    pub admin_archive_repo: Arc<dyn AdminArchiveRepository>,
-    pub authed_token_repo: Arc<dyn AuthedTokenRepository>,
-    pub cap_repo: Arc<dyn CapRepository>,
-    pub user_repo: Arc<dyn AdminUserRepository>,
-    pub user_restriction_repo: Arc<dyn UserRestrictionRepository>,
-    pub idp_repo: Arc<dyn IdpAdminRepository>,
-    pub notice_repo: Arc<dyn NoticeRepository>,
-    pub terms_repo: Arc<dyn TermsRepository>,
-    pub captcha_config_repo: Arc<dyn CaptchaConfigRepository>,
-    pub server_settings_repo: Arc<dyn ServerSettingsRepository>,
-    pub redis_conn: redis::aio::ConnectionManager,
+    pub services: services::AppServiceContainer,
     pub internal_secret: Option<String>,
 }
 
@@ -237,27 +254,39 @@ async fn main() {
     let api_routes = routes::create_api_routes();
     let internal_routes = routes::create_internal_routes();
 
+    let redis_conn = redis::Client::open(std::env::var("REDIS_URL").unwrap())
+        .unwrap()
+        .get_connection_manager()
+        .await
+        .unwrap();
+
+    let service_container = services::AppServiceContainer::new(
+        ContentRepos {
+            board: Arc::new(AdminBoardRepositoryImpl::new(pool.clone())),
+            thread: Arc::new(AdminThreadRepositoryImpl::new(pool.clone())),
+            response: Arc::new(AdminResponseRepositoryImpl::new(pool.clone())),
+            archive: Arc::new(AdminArchiveRepositoryImpl::new(s3_client, s3_bucket_name)),
+        },
+        ModerationRepos {
+            ng_word: Arc::new(NgWordRepositoryImpl::new(pool.clone())),
+            cap: Arc::new(CapRepositoryImpl::new(pool.clone())),
+            user_restriction: Arc::new(UserRestrictionRepositoryImpl::new(pool.clone())),
+            authed_token: Arc::new(AuthedTokenRepositoryImpl::new(pool.clone())),
+        },
+        AdminRepos {
+            user: Arc::new(AdminUserRepositoryImpl::new(pool.clone())),
+            idp: Arc::new(IdpAdminRepositoryImpl::new(pool.clone())),
+            notice: Arc::new(NoticeRepositoryImpl::new(pool.clone())),
+            terms: Arc::new(TermsRepositoryImpl::new(pool.clone())),
+            captcha_config: Arc::new(CaptchaConfigRepositoryImpl::new(pool.clone())),
+            server_settings: Arc::new(ServerSettingsRepositoryImpl::new(pool)),
+        },
+        redis_conn.clone(),
+    );
+
     let state = AppState {
         oauth2_client: client,
-        admin_board_repo: Arc::new(AdminBoardRepositoryImpl::new(pool.clone())),
-        admin_thread_repo: Arc::new(AdminThreadRepositoryImpl::new(pool.clone())),
-        admin_response_repo: Arc::new(AdminResponseRepositoryImpl::new(pool.clone())),
-        ng_word_repo: Arc::new(NgWordRepositoryImpl::new(pool.clone())),
-        redis_conn: redis::Client::open(std::env::var("REDIS_URL").unwrap())
-            .unwrap()
-            .get_connection_manager()
-            .await
-            .unwrap(),
-        admin_archive_repo: Arc::new(AdminArchiveRepositoryImpl::new(s3_client, s3_bucket_name)),
-        authed_token_repo: Arc::new(AuthedTokenRepositoryImpl::new(pool.clone())),
-        cap_repo: Arc::new(CapRepositoryImpl::new(pool.clone())),
-        user_repo: Arc::new(AdminUserRepositoryImpl::new(pool.clone())),
-        user_restriction_repo: Arc::new(UserRestrictionRepositoryImpl::new(pool.clone())),
-        idp_repo: Arc::new(IdpAdminRepositoryImpl::new(pool.clone())),
-        notice_repo: Arc::new(NoticeRepositoryImpl::new(pool.clone())),
-        terms_repo: Arc::new(TermsRepositoryImpl::new(pool.clone())),
-        captcha_config_repo: Arc::new(CaptchaConfigRepositoryImpl::new(pool.clone())),
-        server_settings_repo: Arc::new(ServerSettingsRepositoryImpl::new(pool)),
+        services: service_container,
         internal_secret: std::env::var("EDDIST_INTERNAL_SECRET").ok(),
     };
 

--- a/eddist-admin/src/repository/admin_board_repository.rs
+++ b/eddist-admin/src/repository/admin_board_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use sqlx::{MySqlPool, query, query_as};
 use uuid::Uuid;
 
@@ -394,3 +395,5 @@ impl AdminBoardRepository for AdminBoardRepositoryImpl {
             .ok_or(anyhow::anyhow!("Failed to edit board"))
     }
 }
+
+transaction_repository!(AdminBoardRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/admin_response_repository.rs
+++ b/eddist-admin/src/repository/admin_response_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use chrono::{TimeZone, Utc};
 use eddist_core::domain::client_info::ClientInfo;
 use sqlx::{MySqlPool, query_as, types::Json};
@@ -330,3 +331,5 @@ impl AdminResponseRepository for AdminResponseRepositoryImpl {
         Ok(selection_res_to_res(res))
     }
 }
+
+transaction_repository!(AdminResponseRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/admin_thread_repository.rs
+++ b/eddist-admin/src/repository/admin_thread_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use chrono::Utc;
 use sqlx::MySqlPool;
 use uuid::Uuid;
@@ -250,3 +251,5 @@ impl AdminThreadRepository for AdminThreadRepositoryImpl {
         Ok(())
     }
 }
+
+transaction_repository!(AdminThreadRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/admin_user_repository.rs
+++ b/eddist-admin/src/repository/admin_user_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use std::collections::HashMap;
 
 use uuid::Uuid;
@@ -211,6 +212,8 @@ impl AdminUserRepository for AdminUserRepositoryImpl {
         Ok(())
     }
 }
+
+transaction_repository!(AdminUserRepositoryImpl, 0, MySql);
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct UserIdpsSelection {

--- a/eddist-admin/src/repository/authed_token_repository.rs
+++ b/eddist-admin/src/repository/authed_token_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use chrono::NaiveDateTime;
 use sqlx::{FromRow, MySql, QueryBuilder, Row, query, query_as};
 use uuid::Uuid;
@@ -267,3 +268,5 @@ impl AuthedTokenRepository for AuthedTokenRepositoryImpl {
         Ok(())
     }
 }
+
+transaction_repository!(AuthedTokenRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/cap_repository.rs
+++ b/eddist-admin/src/repository/cap_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use std::collections::HashMap;
 
 use chrono::Utc;
@@ -226,3 +227,5 @@ impl CapRepository for CapRepositoryImpl {
         })
     }
 }
+
+transaction_repository!(CapRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/captcha_config_repository.rs
+++ b/eddist-admin/src/repository/captcha_config_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use chrono::Utc;
 use sqlx::{MySqlPool, query, query_as};
 use uuid::Uuid;
@@ -397,3 +398,5 @@ impl CaptchaConfigRepository for CaptchaConfigRepositoryImpl {
         Ok(())
     }
 }
+
+transaction_repository!(CaptchaConfigRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/idp_repository.rs
+++ b/eddist-admin/src/repository/idp_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use eddist_core::symmetric;
 use sqlx::{MySqlPool, query, query_as};
 use uuid::Uuid;
@@ -183,3 +184,5 @@ impl IdpAdminRepository for IdpAdminRepositoryImpl {
         Ok(())
     }
 }
+
+transaction_repository!(IdpAdminRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/ngword_repository.rs
+++ b/eddist-admin/src/repository/ngword_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use std::collections::HashMap;
 
 use chrono::Utc;
@@ -263,3 +264,5 @@ impl NgWordRepository for NgWordRepositoryImpl {
         })
     }
 }
+
+transaction_repository!(NgWordRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/notice_repository.rs
+++ b/eddist-admin/src/repository/notice_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use chrono::{NaiveDateTime, Utc};
 use eddist_core::domain::notice::Notice;
 use sqlx::{MySqlPool, query, query_as};
@@ -239,3 +240,5 @@ impl NoticeRepository for NoticeRepositoryImpl {
         Ok(())
     }
 }
+
+transaction_repository!(NoticeRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/server_settings_repository.rs
+++ b/eddist-admin/src/repository/server_settings_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use chrono::Utc;
 use eddist_core::{server_settings::KEY_AI_OPENAI_API_KEY, symmetric};
 use sqlx::{MySqlPool, query, query_as};
@@ -111,3 +112,5 @@ impl ServerSettingsRepository for ServerSettingsRepositoryImpl {
         Ok(setting)
     }
 }
+
+transaction_repository!(ServerSettingsRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/terms_repository.rs
+++ b/eddist-admin/src/repository/terms_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use chrono::Utc;
 use eddist_core::domain::terms::Terms;
 use sqlx::{MySqlPool, query, query_as};
@@ -87,3 +88,5 @@ impl TermsRepository for TermsRepositoryImpl {
         Ok(terms)
     }
 }
+
+transaction_repository!(TermsRepositoryImpl, 0, MySql);

--- a/eddist-admin/src/repository/user_restriction_repository.rs
+++ b/eddist-admin/src/repository/user_restriction_repository.rs
@@ -1,3 +1,4 @@
+use crate::transaction_repository;
 use async_trait::async_trait;
 use eddist_core::domain::user_restriction::{
     CreateUserRestrictionRuleInput, RestrictionRuleType, UpdateUserRestrictionRuleInput,
@@ -191,3 +192,5 @@ impl UserRestrictionRepository for UserRestrictionRepositoryImpl {
         Ok(None)
     }
 }
+
+transaction_repository!(UserRestrictionRepositoryImpl, pool, MySql);

--- a/eddist-admin/src/routes/archives.rs
+++ b/eddist-admin/src/routes/archives.rs
@@ -10,6 +10,7 @@ use utoipa::IntoParams;
 
 use crate::{
     AppState,
+    auth::AdminIdentity,
     error::ApiError,
     models::{Res, Thread},
     repository::admin_archive_repository::ArchivedResUpdate,
@@ -80,8 +81,9 @@ pub async fn get_archived_threads(
     }): Query<GetArchivedThreadsQuery>,
 ) -> Result<Json<Vec<Thread>>, ApiError> {
     let threads = state
-        .admin_thread_repo
-        .get_archived_threads_by_filter(
+        .services
+        .archive
+        .get_archived_threads(
             &board_key,
             keyword.as_deref(),
             (
@@ -112,12 +114,10 @@ pub async fn get_archived_thread(
     Path((board_key, thread_id)): Path<(String, u64)>,
 ) -> Result<Json<Thread>, ApiError> {
     let thread = state
-        .admin_thread_repo
-        .get_archived_threads_by_thread_id(&board_key, Some(vec![thread_id]))
-        .await?;
-    let thread = thread
-        .into_iter()
-        .next()
+        .services
+        .archive
+        .get_archived_thread(&board_key, thread_id)
+        .await?
         .ok_or_else(|| ApiError::not_found("Archived thread not found"))?;
     Ok(Json(thread))
 }
@@ -138,8 +138,9 @@ pub async fn get_archived_responses(
     Path((board_key, thread_id)): Path<(String, u64)>,
 ) -> Result<Json<Vec<Res>>, ApiError> {
     let responses = state
-        .admin_response_repo
-        .get_archived_reses_by_thread_id(&board_key, thread_id)
+        .services
+        .archive
+        .get_archived_responses(&board_key, thread_id)
         .await?;
     Ok(Json(responses))
 }
@@ -160,8 +161,9 @@ pub async fn get_dat_archived_thread(
     Path((board_key, thread_number)): Path<(String, u64)>,
 ) -> Result<Json<crate::repository::admin_archive_repository::ArchivedThread>, ApiError> {
     let thread = state
-        .admin_archive_repo
-        .get_thread(&board_key, thread_number)
+        .services
+        .archive
+        .get_dat_archived_thread(&board_key, thread_number)
         .await?;
     Ok(Json(thread))
 }
@@ -182,8 +184,9 @@ pub async fn get_admin_dat_archived_thread(
     Path((board_key, thread_number)): Path<(String, u64)>,
 ) -> Result<Json<crate::repository::admin_archive_repository::ArchivedAdminThread>, ApiError> {
     let thread = state
-        .admin_archive_repo
-        .get_archived_admin_thread(&board_key, thread_number)
+        .services
+        .archive
+        .get_admin_dat_archived_thread(&board_key, thread_number)
         .await?;
     Ok(Json(thread))
 }
@@ -202,12 +205,14 @@ pub async fn get_admin_dat_archived_thread(
 )]
 pub async fn update_archived_res(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path((board_key, thread_number)): Path<(String, u64)>,
     Json(body): Json<Vec<ArchivedResUpdate>>,
 ) -> Result<StatusCode, ApiError> {
     state
-        .admin_archive_repo
-        .update_response(&board_key, thread_number, &body)
+        .services
+        .archive
+        .update_archived_res(&identity, &board_key, thread_number, &body)
         .await?;
     Ok(StatusCode::OK)
 }
@@ -226,11 +231,13 @@ pub async fn update_archived_res(
 )]
 pub async fn delete_archived_res(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path((board_key, thread_number, res_order)): Path<(String, u64, u64)>,
 ) -> Result<StatusCode, ApiError> {
     state
-        .admin_archive_repo
-        .delete_response(&board_key, thread_number, res_order)
+        .services
+        .archive
+        .delete_archived_res(&identity, &board_key, thread_number, res_order)
         .await?;
     Ok(StatusCode::OK)
 }
@@ -248,11 +255,13 @@ pub async fn delete_archived_res(
 )]
 pub async fn delete_archived_thread(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path((board_key, thread_number)): Path<(String, u64)>,
 ) -> Result<StatusCode, ApiError> {
     state
-        .admin_archive_repo
-        .delete_thread(&board_key, thread_number)
+        .services
+        .archive
+        .delete_archived_thread(&identity, &board_key, thread_number)
         .await?;
     Ok(StatusCode::OK)
 }

--- a/eddist-admin/src/routes/auth_tokens.rs
+++ b/eddist-admin/src/routes/auth_tokens.rs
@@ -4,19 +4,13 @@ use axum::{
     http::StatusCode,
     routing::{delete, get, post},
 };
-use eddist_core::{
-    domain::pubsub_repository::{AuthTokenRevoked, CHANNEL_AUTH_TOKEN_REVOKED},
-    proto::encode_auth_token_revoked,
-    utils::is_authed_token_backup_enabled,
-};
-use redis::AsyncCommands;
 use uuid::Uuid;
 
 use crate::{
     AppState,
+    auth::AdminIdentity,
     error::ApiError,
     models::{DeleteAuthedTokenInput, ListAuthedTokensQuery, PaginatedAuthedTokens},
-    repository::authed_token_repository::ListAuthedTokensParams,
 };
 
 pub fn routes() -> Router<AppState> {
@@ -33,8 +27,6 @@ pub fn routes() -> Router<AppState> {
         )
 }
 
-const ALLOWED_SORT_COLUMNS: &[&str] = &["created_at", "authed_at", "last_wrote_at"];
-
 #[utoipa::path(
     get,
     path = "/authed_tokens",
@@ -49,45 +41,12 @@ pub async fn list_authed_tokens(
     State(state): State<AppState>,
     Query(query): Query<ListAuthedTokensQuery>,
 ) -> Result<Json<PaginatedAuthedTokens>, ApiError> {
-    let page = query.page.unwrap_or(1).max(1);
-    let per_page = query.per_page.unwrap_or(50).clamp(1, 100);
-    let offset = (page - 1) as u64 * per_page as u64;
-
-    let sort_column = query
-        .sort_by
-        .as_deref()
-        .filter(|s| ALLOWED_SORT_COLUMNS.contains(s))
-        .unwrap_or("created_at");
-    let sort_asc = query
-        .sort_order
-        .as_deref()
-        .map(|s| s == "asc")
-        .unwrap_or(false);
-
-    let (items, total) = state
-        .authed_token_repo
-        .list_authed_tokens(ListAuthedTokensParams {
-            offset,
-            limit: per_page,
-            origin_ip: query.origin_ip.as_deref(),
-            writing_ua: query.writing_ua.as_deref(),
-            authed_ua: query.authed_ua.as_deref(),
-            asn_num: query.asn_num,
-            validity: query.validity,
-            sort_column,
-            sort_asc,
-        })
+    let result = state
+        .services
+        .authed_token
+        .list_authed_tokens(query)
         .await?;
-
-    let total_pages = ((total as f64) / (per_page as f64)).ceil() as u32;
-
-    Ok(Json(PaginatedAuthedTokens {
-        items,
-        total,
-        page,
-        per_page,
-        total_pages,
-    }))
+    Ok(Json(result))
 }
 
 #[utoipa::path(
@@ -105,7 +64,8 @@ pub async fn get_authed_token(
     Path(authed_token_id): Path<Uuid>,
 ) -> Result<Json<crate::models::AuthedToken>, ApiError> {
     let authed_token = state
-        .authed_token_repo
+        .services
+        .authed_token
         .get_authed_token(authed_token_id)
         .await?;
     Ok(Json(authed_token))
@@ -124,27 +84,15 @@ pub async fn get_authed_token(
 )]
 pub async fn delete_authed_token(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(authed_token_id): Path<Uuid>,
-    Query(DeleteAuthedTokenInput { using_origin_ip }): Query<DeleteAuthedTokenInput>,
+    Query(options): Query<DeleteAuthedTokenInput>,
 ) -> Result<StatusCode, ApiError> {
-    let affected_ids = if !using_origin_ip {
-        state
-            .authed_token_repo
-            .delete_authed_token(authed_token_id)
-            .await?;
-        vec![authed_token_id]
-    } else {
-        state
-            .authed_token_repo
-            .delete_authed_token_by_origin_ip(authed_token_id)
-            .await?
-    };
-    if is_authed_token_backup_enabled() {
-        let mut conn = state.redis_conn.clone();
-        for id in affected_ids {
-            publish_token_revoked(&mut conn, id).await;
-        }
-    }
+    state
+        .services
+        .authed_token
+        .delete_authed_token(&identity, authed_token_id, options)
+        .await?;
     Ok(StatusCode::OK)
 }
 
@@ -163,7 +111,8 @@ pub async fn require_reauth_token(
     Path(authed_token_id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
     state
-        .authed_token_repo
+        .services
+        .authed_token
         .set_require_reauth(authed_token_id)
         .await?;
     Ok(StatusCode::NO_CONTENT)
@@ -184,16 +133,9 @@ pub async fn clear_require_reauth_token(
     Path(authed_token_id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
     state
-        .authed_token_repo
+        .services
+        .authed_token
         .clear_require_reauth(authed_token_id)
         .await?;
     Ok(StatusCode::NO_CONTENT)
-}
-
-pub(crate) async fn publish_token_revoked(
-    conn: &mut redis::aio::ConnectionManager,
-    authed_token_id: Uuid,
-) {
-    let payload = encode_auth_token_revoked(&AuthTokenRevoked { authed_token_id });
-    let _: Result<(), _> = conn.publish(CHANNEL_AUTH_TOKEN_REVOKED, payload).await;
 }

--- a/eddist-admin/src/routes/boards.rs
+++ b/eddist-admin/src/routes/boards.rs
@@ -7,6 +7,7 @@ use eddist_core::domain::board::validate_board_key;
 
 use crate::{
     AppState,
+    auth::AdminIdentity,
     error::ApiError,
     models::{Board, BoardInfo, CreateBoardInput, EditBoardInput},
 };
@@ -28,7 +29,7 @@ pub fn routes() -> Router<AppState> {
     )
 )]
 pub async fn get_boards(State(state): State<AppState>) -> Result<Json<Vec<Board>>, ApiError> {
-    let boards = state.admin_board_repo.get_boards_by_key(None).await?;
+    let boards = state.services.board.get_boards(None).await?;
     Ok(Json(boards))
 }
 
@@ -48,10 +49,10 @@ pub async fn get_board(
     Path(board_key): Path<String>,
 ) -> Result<Json<Board>, ApiError> {
     let board = state
-        .admin_board_repo
-        .get_boards_by_key(Some(vec![board_key]))
-        .await?;
-    let board = board
+        .services
+        .board
+        .get_boards(Some(vec![board_key]))
+        .await?
         .into_iter()
         .next()
         .ok_or_else(|| ApiError::not_found("Board not found"))?;
@@ -74,15 +75,15 @@ pub async fn get_board_info(
     Path(board_key): Path<String>,
 ) -> Result<Json<BoardInfo>, ApiError> {
     let board = state
-        .admin_board_repo
-        .get_boards_by_key(Some(vec![board_key]))
-        .await?;
-    let board = board
+        .services
+        .board
+        .get_boards(Some(vec![board_key]))
+        .await?
         .into_iter()
         .next()
         .ok_or_else(|| ApiError::not_found("Board not found"))?;
 
-    let board_info = state.admin_board_repo.get_board_info(board.id).await?;
+    let board_info = state.services.board.get_board_info(board.id).await?;
     Ok(Json(board_info))
 }
 
@@ -96,6 +97,7 @@ pub async fn get_board_info(
 )]
 pub async fn create_board(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Json(body): Json<CreateBoardInput>,
 ) -> Result<Json<Board>, ApiError> {
     if validate_board_key(&body.board_key).is_err() {
@@ -104,7 +106,7 @@ pub async fn create_board(
         ));
     }
 
-    let board = state.admin_board_repo.create_board(body).await?;
+    let board = state.services.board.create_board(&identity, body).await?;
     Ok(Json(board))
 }
 
@@ -121,9 +123,14 @@ pub async fn create_board(
 )]
 pub async fn edit_board(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(board_key): Path<String>,
     Json(body): Json<EditBoardInput>,
 ) -> Result<Json<Board>, ApiError> {
-    let board = state.admin_board_repo.edit_board(&board_key, body).await?;
+    let board = state
+        .services
+        .board
+        .edit_board(&identity, &board_key, body)
+        .await?;
     Ok(Json(board))
 }

--- a/eddist-admin/src/routes/captcha.rs
+++ b/eddist-admin/src/routes/captcha.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::{
     AppState,
-    auth::AdminEmail,
+    auth::AdminIdentity,
     error::ApiError,
     models::{CaptchaConfig, CreateCaptchaConfigInput, UpdateCaptchaConfigInput},
 };
@@ -33,7 +33,7 @@ pub fn routes() -> Router<AppState> {
 pub async fn list_captcha_configs(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<CaptchaConfig>>, ApiError> {
-    let configs = state.captcha_config_repo.get_all().await?;
+    let configs = state.services.content_admin.list_captcha_configs().await?;
     Ok(Json(configs))
 }
 
@@ -54,8 +54,9 @@ pub async fn get_captcha_config(
     Path(id): Path<Uuid>,
 ) -> Result<Json<CaptchaConfig>, ApiError> {
     let config = state
-        .captcha_config_repo
-        .get_by_id(id)
+        .services
+        .content_admin
+        .get_captcha_config(id)
         .await?
         .ok_or_else(|| ApiError::not_found("Captcha config not found"))?;
     Ok(Json(config))
@@ -74,12 +75,13 @@ pub async fn get_captcha_config(
 )]
 pub async fn create_captcha_config(
     State(state): State<AppState>,
-    AdminEmail(email): AdminEmail,
+    identity: AdminIdentity,
     Json(input): Json<CreateCaptchaConfigInput>,
 ) -> Result<(StatusCode, Json<CaptchaConfig>), ApiError> {
     let config = state
-        .captcha_config_repo
-        .create(input, Some(email))
+        .services
+        .content_admin
+        .create_captcha_config(&identity, input)
         .await
         .map_err(|e| ApiError::bad_request(format!("Failed to create captcha config: {e}")))?;
     Ok((StatusCode::CREATED, Json(config)))
@@ -102,13 +104,14 @@ pub async fn create_captcha_config(
 )]
 pub async fn update_captcha_config(
     State(state): State<AppState>,
-    AdminEmail(email): AdminEmail,
+    identity: AdminIdentity,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateCaptchaConfigInput>,
 ) -> Result<Json<CaptchaConfig>, ApiError> {
     let config = state
-        .captcha_config_repo
-        .update(id, input, Some(email))
+        .services
+        .content_admin
+        .update_captcha_config(&identity, id, input)
         .await
         .map_err(|e| {
             if e.to_string().contains("not found") {
@@ -135,12 +138,13 @@ pub async fn update_captcha_config(
 )]
 pub async fn delete_captcha_config(
     State(state): State<AppState>,
-    AdminEmail(_email): AdminEmail,
+    identity: AdminIdentity,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
     state
-        .captcha_config_repo
-        .delete(id)
+        .services
+        .content_admin
+        .delete_captcha_config(&identity, id)
         .await
         .map_err(|e| ApiError::not_found(format!("Failed to delete captcha config: {e}")))?;
     Ok(StatusCode::NO_CONTENT)

--- a/eddist-admin/src/routes/idps.rs
+++ b/eddist-admin/src/routes/idps.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use crate::{
     AppState,
+    auth::AdminIdentity,
     error::ApiError,
     models::idp::{CreateIdpInput, Idp, UpdateIdpInput},
 };
@@ -30,7 +31,7 @@ pub fn routes() -> Router<AppState> {
     )
 )]
 pub async fn list_idps(State(state): State<AppState>) -> Result<Json<Vec<Idp>>, ApiError> {
-    let idps = state.idp_repo.get_all().await?;
+    let idps = state.services.content_admin.list_idps().await?;
     Ok(Json(idps))
 }
 
@@ -51,8 +52,9 @@ pub async fn get_idp(
     Path(id): Path<Uuid>,
 ) -> Result<Json<Idp>, ApiError> {
     let idp = state
-        .idp_repo
-        .get_by_id(id)
+        .services
+        .content_admin
+        .get_idp(id)
         .await?
         .ok_or_else(|| ApiError::not_found("IdP not found"))?;
     Ok(Json(idp))
@@ -70,11 +72,13 @@ pub async fn get_idp(
 )]
 pub async fn create_idp(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Json(input): Json<CreateIdpInput>,
 ) -> Result<(StatusCode, Json<Idp>), ApiError> {
     let idp = state
-        .idp_repo
-        .create(input)
+        .services
+        .content_admin
+        .create_idp(&identity, input)
         .await
         .map_err(|e| ApiError::bad_request(format!("Failed to create IdP: {e}")))?;
     Ok((StatusCode::CREATED, Json(idp)))
@@ -96,16 +100,22 @@ pub async fn create_idp(
 )]
 pub async fn update_idp(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateIdpInput>,
 ) -> Result<Json<Idp>, ApiError> {
-    let idp = state.idp_repo.update(id, input).await.map_err(|e| {
-        if e.to_string().contains("not found") {
-            ApiError::not_found("IdP not found")
-        } else {
-            ApiError::bad_request(format!("Failed to update IdP: {e}"))
-        }
-    })?;
+    let idp = state
+        .services
+        .content_admin
+        .update_idp(&identity, id, input)
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("not found") {
+                ApiError::not_found("IdP not found")
+            } else {
+                ApiError::bad_request(format!("Failed to update IdP: {e}"))
+            }
+        })?;
     Ok(Json(idp))
 }
 
@@ -123,11 +133,13 @@ pub async fn update_idp(
 )]
 pub async fn delete_idp(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
     state
-        .idp_repo
-        .delete(id)
+        .services
+        .content_admin
+        .delete_idp(&identity, id)
         .await
         .map_err(|e| ApiError::not_found(format!("Failed to delete IdP: {e}")))?;
     Ok(StatusCode::NO_CONTENT)

--- a/eddist-admin/src/routes/internal.rs
+++ b/eddist-admin/src/routes/internal.rs
@@ -1,6 +1,4 @@
 use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
-use eddist_core::{redis_keys::authed_token_suspended_key, utils::is_authed_token_backup_enabled};
-use redis::AsyncCommands;
 use serde::Deserialize;
 use uuid::Uuid;
 
@@ -32,29 +30,20 @@ pub async fn suspend_authed_token(
         return Err(ApiError::bad_request("ttl_seconds must be greater than 0"));
     }
 
-    let authed_token = state
-        .authed_token_repo
-        .get_authed_token(input.authed_token_id)
+    state
+        .services
+        .authed_token
+        .suspend_authed_token(input.authed_token_id, input.ttl_seconds)
         .await
         .map_err(|e| {
-            if let Some(sqlx::Error::RowNotFound) = e.downcast_ref::<sqlx::Error>() {
+            if e.to_string().contains("not found") {
                 ApiError::not_found("authed token not found")
+            } else if e.to_string().contains("permanently revoked") {
+                ApiError::bad_request(e.to_string())
             } else {
                 ApiError::Internal(e)
             }
         })?;
-
-    if !authed_token.validity {
-        return Err(ApiError::bad_request(
-            "this token has already been permanently revoked",
-        ));
-    }
-
-    let key = authed_token_suspended_key(&input.authed_token_id.to_string());
-    let mut conn = state.redis_conn.clone();
-    conn.set_ex::<_, _, ()>(&key, "1", input.ttl_seconds)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!(e)))?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -68,15 +57,17 @@ pub async fn revoke_authed_token(
     State(state): State<AppState>,
     Json(input): Json<RevokeAuthedTokenInput>,
 ) -> Result<StatusCode, ApiError> {
+    // Internal routes don't have a session-based actor; use a system placeholder.
+    let system_actor = crate::auth::AdminIdentity {
+        sub: "system".to_string(),
+        email: "system@internal".to_string(),
+        username: "system".to_string(),
+    };
     state
-        .authed_token_repo
-        .delete_authed_token(input.authed_token_id)
+        .services
+        .authed_token
+        .revoke_authed_token(&system_actor, input.authed_token_id)
         .await?;
-
-    if is_authed_token_backup_enabled() {
-        let mut conn = state.redis_conn.clone();
-        super::auth_tokens::publish_token_revoked(&mut conn, input.authed_token_id).await;
-    }
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/eddist-admin/src/routes/moderation.rs
+++ b/eddist-admin/src/routes/moderation.rs
@@ -4,14 +4,12 @@ use axum::{
     http::StatusCode,
     routing::{delete, get, patch, post},
 };
-use eddist_core::domain::user_restriction::{
-    CreateUserRestrictionRuleInput, UpdateUserRestrictionRuleInput, UserRestrictionRule,
-};
+use eddist_core::domain::user_restriction::{UpdateUserRestrictionRuleInput, UserRestrictionRule};
 use uuid::Uuid;
 
 use crate::{
     AppState,
-    auth::AdminEmail,
+    auth::AdminIdentity,
     error::ApiError,
     models::{
         Cap, CreateRestrictionRuleRequest, CreationCapInput, CreationNgWordInput, NgWord,
@@ -54,7 +52,7 @@ pub fn routes() -> Router<AppState> {
     )
 )]
 pub async fn get_ng_words(State(state): State<AppState>) -> Result<Json<Vec<NgWord>>, ApiError> {
-    let ng_words = state.ng_word_repo.get_ng_words().await?;
+    let ng_words = state.services.moderation.get_ng_words().await?;
     Ok(Json(ng_words))
 }
 
@@ -68,11 +66,13 @@ pub async fn get_ng_words(State(state): State<AppState>) -> Result<Json<Vec<NgWo
 )]
 pub async fn create_ng_word(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Json(body): Json<CreationNgWordInput>,
 ) -> Result<Json<NgWord>, ApiError> {
     let ng_word = state
-        .ng_word_repo
-        .create_ng_word(&body.name, &body.word)
+        .services
+        .moderation
+        .create_ng_word(&identity, body)
         .await?;
     Ok(Json(ng_word))
 }
@@ -90,17 +90,14 @@ pub async fn create_ng_word(
 )]
 pub async fn update_ng_word(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(ng_word_id): Path<Uuid>,
     Json(body): Json<UpdateNgWordInput>,
 ) -> Result<Json<NgWord>, ApiError> {
     let ng_word = state
-        .ng_word_repo
-        .update_ng_word(
-            ng_word_id,
-            body.name.as_deref(),
-            body.word.as_deref(),
-            body.board_ids,
-        )
+        .services
+        .moderation
+        .update_ng_word(&identity, ng_word_id, body)
         .await?;
     Ok(Json(ng_word))
 }
@@ -117,9 +114,14 @@ pub async fn update_ng_word(
 )]
 pub async fn delete_ng_word(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(ng_word_id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
-    state.ng_word_repo.delete_ng_word(ng_word_id).await?;
+    state
+        .services
+        .moderation
+        .delete_ng_word(&identity, ng_word_id)
+        .await?;
     Ok(StatusCode::OK)
 }
 
@@ -132,7 +134,7 @@ pub async fn delete_ng_word(
     )
 )]
 pub async fn get_caps(State(state): State<AppState>) -> Result<Json<Vec<Cap>>, ApiError> {
-    let caps = state.cap_repo.get_caps().await?;
+    let caps = state.services.moderation.get_caps().await?;
     Ok(Json(caps))
 }
 
@@ -146,17 +148,13 @@ pub async fn get_caps(State(state): State<AppState>) -> Result<Json<Vec<Cap>>, A
 )]
 pub async fn create_cap(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Json(body): Json<CreationCapInput>,
 ) -> Result<Json<Cap>, ApiError> {
-    let tinker_secret = std::env::var("TINKER_SECRET")
-        .map_err(|_| ApiError::Internal(anyhow::anyhow!("TINKER_SECRET not configured")))?;
     let cap = state
-        .cap_repo
-        .create_cap(
-            &body.name,
-            &body.description,
-            &eddist_core::domain::cap::calculate_cap_hash(&body.password, &tinker_secret),
-        )
+        .services
+        .moderation
+        .create_cap(&identity, body)
         .await?;
     Ok(Json(cap))
 }
@@ -174,23 +172,14 @@ pub async fn create_cap(
 )]
 pub async fn update_cap(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(cap_id): Path<Uuid>,
     Json(body): Json<UpdateCapInput>,
 ) -> Result<Json<Cap>, ApiError> {
     let cap = state
-        .cap_repo
-        .update_cap(
-            cap_id,
-            body.name.as_deref(),
-            body.description.as_deref(),
-            body.password
-                .map(|x| {
-                    let secret = std::env::var("TINKER_SECRET").unwrap_or_default();
-                    eddist_core::domain::cap::calculate_cap_hash(&x, &secret)
-                })
-                .as_deref(),
-            body.board_ids,
-        )
+        .services
+        .moderation
+        .update_cap(&identity, cap_id, body)
         .await?;
     Ok(Json(cap))
 }
@@ -207,9 +196,14 @@ pub async fn update_cap(
 )]
 pub async fn delete_cap(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(cap_id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
-    state.cap_repo.delete_cap(cap_id).await?;
+    state
+        .services
+        .moderation
+        .delete_cap(&identity, cap_id)
+        .await?;
     Ok(StatusCode::OK)
 }
 
@@ -225,10 +219,10 @@ pub async fn get_restriction_rules(
     State(app_state): State<AppState>,
 ) -> Result<Json<Vec<UserRestrictionRule>>, ApiError> {
     let rules = app_state
-        .user_restriction_repo
-        .get_all_rules()
-        .await
-        .unwrap_or_default();
+        .services
+        .moderation
+        .get_restriction_rules()
+        .await?;
     Ok(Json(rules))
 }
 
@@ -242,18 +236,20 @@ pub async fn get_restriction_rules(
 )]
 pub async fn create_restriction_rule(
     State(app_state): State<AppState>,
-    AdminEmail(admin_email): AdminEmail,
+    identity: AdminIdentity,
     Json(req): Json<CreateRestrictionRuleRequest>,
 ) -> Result<(StatusCode, Json<UserRestrictionRule>), ApiError> {
-    let input = CreateUserRestrictionRuleInput {
-        name: req.name,
-        rule_type: req.rule_type.into(),
-        rule_value: req.rule_value,
-        expires_at: req.expires_at,
-        created_by_email: admin_email,
-    };
-
-    let rule = app_state.user_restriction_repo.create_rule(input).await?;
+    let rule = app_state
+        .services
+        .moderation
+        .create_restriction_rule(
+            &identity,
+            req.name,
+            req.rule_type.into(),
+            req.rule_value,
+            req.expires_at,
+        )
+        .await?;
     Ok((StatusCode::CREATED, Json(rule)))
 }
 
@@ -271,6 +267,7 @@ pub async fn create_restriction_rule(
 pub async fn update_restriction_rule(
     Path(rule_id): Path<Uuid>,
     State(app_state): State<AppState>,
+    identity: AdminIdentity,
     Json(req): Json<UpdateRestrictionRuleRequest>,
 ) -> Result<Json<()>, ApiError> {
     let input = UpdateUserRestrictionRuleInput {
@@ -280,8 +277,11 @@ pub async fn update_restriction_rule(
         rule_value: req.rule_value,
         expires_at: req.expires_at,
     };
-
-    app_state.user_restriction_repo.update_rule(input).await?;
+    app_state
+        .services
+        .moderation
+        .update_restriction_rule(&identity, input)
+        .await?;
     Ok(Json(()))
 }
 
@@ -298,8 +298,13 @@ pub async fn update_restriction_rule(
 pub async fn delete_restriction_rule(
     Path(rule_id): Path<Uuid>,
     State(app_state): State<AppState>,
+    identity: AdminIdentity,
 ) -> Result<Json<()>, ApiError> {
-    app_state.user_restriction_repo.delete_rule(rule_id).await?;
+    app_state
+        .services
+        .moderation
+        .delete_restriction_rule(&identity, rule_id)
+        .await?;
     Ok(Json(()))
 }
 
@@ -318,8 +323,9 @@ pub async fn get_restriction_rule(
     State(app_state): State<AppState>,
 ) -> Result<Json<Option<UserRestrictionRule>>, ApiError> {
     let rule = app_state
-        .user_restriction_repo
-        .get_rule_by_id(rule_id)
+        .services
+        .moderation
+        .get_restriction_rule(rule_id)
         .await?;
     Ok(Json(rule))
 }

--- a/eddist-admin/src/routes/notices.rs
+++ b/eddist-admin/src/routes/notices.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::{
     AppState,
-    auth::{AdminEmail, AdminSession},
+    auth::AdminIdentity,
     error::ApiError,
     models::Notice,
     repository::notice_repository::{CreateNoticeInput, UpdateNoticeInput},
@@ -36,31 +36,6 @@ const fn default_limit() -> u32 {
     20
 }
 
-/// Helper function to check if the current admin is the author of a notice
-async fn check_notice_author(
-    state: &AppState,
-    admin_session: &AdminSession,
-    notice_id: Uuid,
-) -> Result<eddist_core::domain::notice::Notice, ApiError> {
-    let current_admin_email = admin_session
-        .get_admin_email()
-        .ok_or_else(ApiError::unauthorized)?;
-
-    let existing_notice = state
-        .notice_repo
-        .get_notice_by_id(notice_id)
-        .await?
-        .ok_or_else(|| ApiError::not_found("Notice not found"))?;
-
-    if existing_notice.author_email.as_ref() != Some(&current_admin_email) {
-        return Err(ApiError::forbidden(
-            "You can only modify notices you created",
-        ));
-    }
-
-    Ok(existing_notice)
-}
-
 #[utoipa::path(
     get,
     path = "/notices/",
@@ -74,10 +49,11 @@ pub async fn get_notices(
 ) -> Result<Json<Vec<Notice>>, ApiError> {
     let limit = query.limit.min(100);
     let notices = state
-        .notice_repo
-        .get_notices_paginated(query.page, limit)
+        .services
+        .content_admin
+        .get_notices(query.page, limit)
         .await?;
-    Ok(Json(notices.into_iter().map(Notice::from).collect()))
+    Ok(Json(notices))
 }
 
 #[utoipa::path(
@@ -96,11 +72,12 @@ pub async fn get_notice(
     Path(id): Path<Uuid>,
 ) -> Result<Json<Notice>, ApiError> {
     let notice = state
-        .notice_repo
-        .get_notice_by_id(id)
+        .services
+        .content_admin
+        .get_notice(id)
         .await?
         .ok_or_else(|| ApiError::not_found("Notice not found"))?;
-    Ok(Json(notice.into()))
+    Ok(Json(notice))
 }
 
 #[utoipa::path(
@@ -115,7 +92,7 @@ pub async fn get_notice(
 )]
 pub async fn create_notice(
     State(state): State<AppState>,
-    AdminEmail(email): AdminEmail,
+    identity: AdminIdentity,
     Json(input): Json<CreateNoticeInput>,
 ) -> Result<(StatusCode, Json<Notice>), ApiError> {
     if input.slug == "latest" {
@@ -123,11 +100,12 @@ pub async fn create_notice(
     }
 
     let notice = state
-        .notice_repo
-        .create_notice(input, Some(email))
+        .services
+        .content_admin
+        .create_notice(&identity, input)
         .await
         .map_err(|e| ApiError::bad_request(format!("Failed to create notice: {e}")))?;
-    Ok((StatusCode::CREATED, Json(notice.into())))
+    Ok((StatusCode::CREATED, Json(notice)))
 }
 
 #[utoipa::path(
@@ -147,19 +125,31 @@ pub async fn create_notice(
 )]
 pub async fn update_notice(
     State(state): State<AppState>,
-    admin_session: AdminSession,
+    identity: AdminIdentity,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateNoticeInput>,
 ) -> Result<Json<Notice>, ApiError> {
-    check_notice_author(&state, &admin_session, id).await?;
+    state
+        .services
+        .content_admin
+        .check_notice_author(&identity, id)
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("Forbidden") {
+                ApiError::forbidden(e.to_string())
+            } else {
+                ApiError::not_found(e.to_string())
+            }
+        })?;
 
     if matches!(&input.slug, Some(slug) if slug == "latest") {
         return Err(ApiError::bad_request("'latest' is a reserved slug"));
     }
 
     let notice = state
-        .notice_repo
-        .update_notice(id, input)
+        .services
+        .content_admin
+        .update_notice(&identity, id, input)
         .await
         .map_err(|e| {
             if e.to_string().contains("not found") {
@@ -168,7 +158,7 @@ pub async fn update_notice(
                 ApiError::bad_request(format!("Failed to update notice: {e}"))
             }
         })?;
-    Ok(Json(notice.into()))
+    Ok(Json(notice))
 }
 
 #[utoipa::path(
@@ -186,14 +176,26 @@ pub async fn update_notice(
 )]
 pub async fn delete_notice(
     State(state): State<AppState>,
-    admin_session: AdminSession,
+    identity: AdminIdentity,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
-    check_notice_author(&state, &admin_session, id).await?;
+    state
+        .services
+        .content_admin
+        .check_notice_author(&identity, id)
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("Forbidden") {
+                ApiError::forbidden(e.to_string())
+            } else {
+                ApiError::not_found(e.to_string())
+            }
+        })?;
 
     state
-        .notice_repo
-        .delete_notice(id)
+        .services
+        .content_admin
+        .delete_notice(&identity, id)
         .await
         .map_err(|e| ApiError::not_found(format!("Failed to delete notice: {e}")))?;
     Ok(StatusCode::NO_CONTENT)

--- a/eddist-admin/src/routes/server_settings.rs
+++ b/eddist-admin/src/routes/server_settings.rs
@@ -6,6 +6,7 @@ use axum::{
 
 use crate::{
     AppState,
+    auth::AdminIdentity,
     error::ApiError,
     models::server_settings::{ServerSetting, UpsertServerSettingInput},
 };
@@ -29,7 +30,7 @@ pub fn routes() -> Router<AppState> {
 pub async fn list_server_settings(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<ServerSetting>>, ApiError> {
-    let settings = state.server_settings_repo.get_all().await?;
+    let settings = state.services.content_admin.list_server_settings().await?;
     Ok(Json(settings))
 }
 
@@ -45,6 +46,7 @@ pub async fn list_server_settings(
 )]
 pub async fn upsert_server_setting(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Json(input): Json<UpsertServerSettingInput>,
 ) -> Result<Json<ServerSetting>, ApiError> {
     if !ServerSettingKey::ALL
@@ -63,8 +65,9 @@ pub async fn upsert_server_setting(
     }
 
     let setting = state
-        .server_settings_repo
-        .upsert(input)
+        .services
+        .content_admin
+        .upsert_server_setting(&identity, input)
         .await
         .map_err(|e| ApiError::bad_request(format!("Failed to upsert server setting: {e}")))?;
     Ok(Json(setting))

--- a/eddist-admin/src/routes/terms.rs
+++ b/eddist-admin/src/routes/terms.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 
 use crate::{
-    AppState, auth::AdminEmail, error::ApiError, models::Terms,
+    AppState, auth::AdminIdentity, error::ApiError, models::Terms,
     repository::terms_repository::UpdateTermsInput,
 };
 
@@ -25,11 +25,12 @@ pub fn routes() -> Router<AppState> {
 )]
 pub async fn get_terms(State(state): State<AppState>) -> Result<Json<Terms>, ApiError> {
     let terms = state
-        .terms_repo
+        .services
+        .content_admin
         .get_terms()
         .await?
         .ok_or_else(|| ApiError::not_found("Terms not found"))?;
-    Ok(Json(terms.into()))
+    Ok(Json(terms))
 }
 
 #[utoipa::path(
@@ -45,12 +46,13 @@ pub async fn get_terms(State(state): State<AppState>) -> Result<Json<Terms>, Api
 )]
 pub async fn update_terms(
     State(state): State<AppState>,
-    AdminEmail(email): AdminEmail,
+    identity: AdminIdentity,
     Json(input): Json<UpdateTermsInput>,
 ) -> Result<Json<Terms>, ApiError> {
     let terms = state
-        .terms_repo
-        .update_terms(input, Some(email))
+        .services
+        .content_admin
+        .update_terms(&identity, input)
         .await
         .map_err(|e| {
             if e.to_string().contains("not found") {
@@ -59,5 +61,5 @@ pub async fn update_terms(
                 ApiError::bad_request(format!("Failed to update terms: {e}"))
             }
         })?;
-    Ok(Json(terms.into()))
+    Ok(Json(terms))
 }

--- a/eddist-admin/src/routes/threads.rs
+++ b/eddist-admin/src/routes/threads.rs
@@ -4,11 +4,11 @@ use axum::{
     http::StatusCode,
     routing::{get, patch, post},
 };
-use eddist_core::domain::res::ResView;
 use uuid::Uuid;
 
 use crate::{
     AppState,
+    auth::AdminIdentity,
     error::ApiError,
     models::{Res, Thread, ThreadCompactionInput, UpdateResInput},
 };
@@ -42,10 +42,7 @@ pub async fn get_threads(
     State(state): State<AppState>,
     Path(board_key): Path<String>,
 ) -> Result<Json<Vec<Thread>>, ApiError> {
-    let threads = state
-        .admin_thread_repo
-        .get_threads_by_thread_id(&board_key, None)
-        .await?;
+    let threads = state.services.thread.get_threads(&board_key).await?;
     Ok(Json(threads))
 }
 
@@ -66,12 +63,10 @@ pub async fn get_thread(
     Path((board_key, thread_id)): Path<(String, u64)>,
 ) -> Result<Json<Thread>, ApiError> {
     let thread = state
-        .admin_thread_repo
-        .get_threads_by_thread_id(&board_key, Some(vec![thread_id]))
-        .await?;
-    let thread = thread
-        .into_iter()
-        .next()
+        .services
+        .thread
+        .get_thread(&board_key, thread_id)
+        .await?
         .ok_or_else(|| ApiError::not_found("Thread not found"))?;
     Ok(Json(thread))
 }
@@ -92,8 +87,9 @@ pub async fn get_responses(
     Path((board_key, thread_id)): Path<(String, u64)>,
 ) -> Result<Json<Vec<Res>>, ApiError> {
     let responses = state
-        .admin_response_repo
-        .get_reses_by_thread_id(&board_key, thread_id)
+        .services
+        .thread
+        .get_responses(&board_key, thread_id)
         .await?;
     Ok(Json(responses))
 }
@@ -113,62 +109,16 @@ pub async fn get_responses(
 )]
 pub async fn update_response(
     State(state): State<AppState>,
-    Path((_a, _aa, res_id)): Path<(String, u64, Uuid)>,
+    identity: AdminIdentity,
+    Path((board_key, thread_id, res_id)): Path<(String, u64, Uuid)>,
     Json(body): Json<UpdateResInput>,
 ) -> Result<Json<Res>, ApiError> {
-    let (res, default_name, board_key, thread_number, thread_title) =
-        state.admin_response_repo.get_res(res_id).await?;
-    let updated_res = state
-        .admin_response_repo
-        .update_res(
-            res_id,
-            body.author_name.clone(),
-            body.mail.clone(),
-            body.body.clone(),
-            body.is_abone,
-        )
+    let res = state
+        .services
+        .thread
+        .update_response(&identity, &board_key, thread_id, res_id, body)
         .await?;
-    let author_name = if let Some(author_name) = body.author_name {
-        author_name
-    } else {
-        res.author_name.unwrap_or(default_name.clone())
-    };
-    let mail = if let Some(mail) = body.mail {
-        mail
-    } else {
-        res.mail.unwrap_or_default()
-    };
-    let is_abone = if let Some(is_abone) = body.is_abone {
-        is_abone
-    } else {
-        res.is_abone
-    };
-    let res_body = if let Some(body) = body.body {
-        body
-    } else {
-        res.body
-    };
-
-    let res_view = ResView {
-        author_name,
-        mail,
-        body: res_body,
-        created_at: res.created_at,
-        author_id: res.author_id,
-        is_abone,
-    };
-
-    let res_view = res_view.get_sjis_bytes(&default_name, thread_title.as_deref());
-    let mut conn = state.redis_conn;
-    let _ = conn
-        .send_packed_command(&redis::Cmd::lset(
-            format!("threads:{}:{}", board_key, thread_number),
-            res.res_order as isize - 1,
-            res_view.get_inner(),
-        ))
-        .await;
-
-    Ok(Json(updated_res))
+    Ok(Json(res))
 }
 
 #[utoipa::path(
@@ -184,12 +134,14 @@ pub async fn update_response(
 )]
 pub async fn threads_compaction(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(board_key): Path<String>,
     Json(body): Json<ThreadCompactionInput>,
 ) -> Result<StatusCode, ApiError> {
     state
-        .admin_thread_repo
-        .compact_threads(&board_key, body.target_count)
+        .services
+        .thread
+        .compact_threads(&identity, &board_key, body.target_count)
         .await?;
     Ok(StatusCode::OK)
 }

--- a/eddist-admin/src/routes/users.rs
+++ b/eddist-admin/src/routes/users.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 
 use crate::{
     AppState,
+    auth::AdminIdentity,
     error::ApiError,
     models::{User, UserSearchQuery, UserStatusUpdateInput},
 };
@@ -31,10 +32,7 @@ pub async fn search_users(
     State(state): State<AppState>,
     Query(query): Query<UserSearchQuery>,
 ) -> Result<Json<Vec<User>>, ApiError> {
-    let users = state
-        .user_repo
-        .search_users(query.user_id, query.user_name, query.authed_token_id)
-        .await?;
+    let users = state.services.user.search_users(query).await?;
     Ok(Json(users))
 }
 
@@ -51,22 +49,14 @@ pub async fn search_users(
 )]
 pub async fn update_user_status(
     State(state): State<AppState>,
+    identity: AdminIdentity,
     Path(user_id): Path<Uuid>,
     Json(body): Json<UserStatusUpdateInput>,
 ) -> Result<Json<User>, ApiError> {
-    state
-        .user_repo
-        .update_user_status(user_id, body.enabled)
+    let user = state
+        .services
+        .user
+        .update_user_status(&identity, user_id, body.enabled)
         .await?;
-
-    let users = state
-        .user_repo
-        .search_users(Some(user_id), None, None)
-        .await?;
-
-    let user = users
-        .into_iter()
-        .next()
-        .ok_or_else(|| ApiError::not_found("User not found after update"))?;
     Ok(Json(user))
 }

--- a/eddist-admin/src/services/archive_service.rs
+++ b/eddist-admin/src/services/archive_service.rs
@@ -1,0 +1,178 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+
+use crate::{
+    auth::AdminIdentity,
+    models::{Res, Thread},
+    repository::{
+        admin_archive_repository::{
+            AdminArchiveRepository, ArchivedAdminThread, ArchivedResUpdate, ArchivedThread,
+        },
+        admin_response_repository::AdminResponseRepository,
+        admin_thread_repository::AdminThreadRepository,
+    },
+};
+
+#[async_trait::async_trait]
+pub trait AdminArchiveService: Send + Sync {
+    async fn get_archived_threads(
+        &self,
+        board_key: &str,
+        keyword: Option<&str>,
+        date_range: (Option<DateTime<Utc>>, Option<DateTime<Utc>>),
+        page: u64,
+        limit: u64,
+    ) -> anyhow::Result<Vec<Thread>>;
+    async fn get_archived_thread(
+        &self,
+        board_key: &str,
+        thread_id: u64,
+    ) -> anyhow::Result<Option<Thread>>;
+    async fn get_archived_responses(
+        &self,
+        board_key: &str,
+        thread_id: u64,
+    ) -> anyhow::Result<Vec<Res>>;
+    async fn get_dat_archived_thread(
+        &self,
+        board_key: &str,
+        thread_number: u64,
+    ) -> anyhow::Result<ArchivedThread>;
+    async fn get_admin_dat_archived_thread(
+        &self,
+        board_key: &str,
+        thread_number: u64,
+    ) -> anyhow::Result<ArchivedAdminThread>;
+    async fn update_archived_res(
+        &self,
+        actor: &AdminIdentity,
+        board_key: &str,
+        thread_number: u64,
+        updates: &[ArchivedResUpdate],
+    ) -> anyhow::Result<()>;
+    async fn delete_archived_res(
+        &self,
+        actor: &AdminIdentity,
+        board_key: &str,
+        thread_number: u64,
+        res_order: u64,
+    ) -> anyhow::Result<()>;
+    async fn delete_archived_thread(
+        &self,
+        actor: &AdminIdentity,
+        board_key: &str,
+        thread_number: u64,
+    ) -> anyhow::Result<()>;
+}
+
+pub struct ArchiveServiceImpl {
+    thread_repo: Arc<dyn AdminThreadRepository>,
+    response_repo: Arc<dyn AdminResponseRepository>,
+    archive_repo: Arc<dyn AdminArchiveRepository>,
+}
+
+impl ArchiveServiceImpl {
+    pub fn new(
+        thread_repo: Arc<dyn AdminThreadRepository>,
+        response_repo: Arc<dyn AdminResponseRepository>,
+        archive_repo: Arc<dyn AdminArchiveRepository>,
+    ) -> Self {
+        Self {
+            thread_repo,
+            response_repo,
+            archive_repo,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AdminArchiveService for ArchiveServiceImpl {
+    async fn get_archived_threads(
+        &self,
+        board_key: &str,
+        keyword: Option<&str>,
+        date_range: (Option<DateTime<Utc>>, Option<DateTime<Utc>>),
+        page: u64,
+        limit: u64,
+    ) -> anyhow::Result<Vec<Thread>> {
+        self.thread_repo
+            .get_archived_threads_by_filter(board_key, keyword, date_range, page, limit)
+            .await
+    }
+
+    async fn get_archived_thread(
+        &self,
+        board_key: &str,
+        thread_id: u64,
+    ) -> anyhow::Result<Option<Thread>> {
+        let threads = self
+            .thread_repo
+            .get_archived_threads_by_thread_id(board_key, Some(vec![thread_id]))
+            .await?;
+        Ok(threads.into_iter().next())
+    }
+
+    async fn get_archived_responses(
+        &self,
+        board_key: &str,
+        thread_id: u64,
+    ) -> anyhow::Result<Vec<Res>> {
+        self.response_repo
+            .get_archived_reses_by_thread_id(board_key, thread_id)
+            .await
+    }
+
+    async fn get_dat_archived_thread(
+        &self,
+        board_key: &str,
+        thread_number: u64,
+    ) -> anyhow::Result<ArchivedThread> {
+        self.archive_repo.get_thread(board_key, thread_number).await
+    }
+
+    async fn get_admin_dat_archived_thread(
+        &self,
+        board_key: &str,
+        thread_number: u64,
+    ) -> anyhow::Result<ArchivedAdminThread> {
+        self.archive_repo
+            .get_archived_admin_thread(board_key, thread_number)
+            .await
+    }
+
+    async fn update_archived_res(
+        &self,
+        _actor: &AdminIdentity,
+        board_key: &str,
+        thread_number: u64,
+        updates: &[ArchivedResUpdate],
+    ) -> anyhow::Result<()> {
+        self.archive_repo
+            .update_response(board_key, thread_number, updates)
+            .await
+    }
+
+    async fn delete_archived_res(
+        &self,
+        _actor: &AdminIdentity,
+        board_key: &str,
+        thread_number: u64,
+        res_order: u64,
+    ) -> anyhow::Result<()> {
+        self.archive_repo
+            .delete_response(board_key, thread_number, res_order)
+            .await
+    }
+
+    async fn delete_archived_thread(
+        &self,
+        _actor: &AdminIdentity,
+        board_key: &str,
+        thread_number: u64,
+    ) -> anyhow::Result<()> {
+        self.archive_repo
+            .delete_thread(board_key, thread_number)
+            .await
+    }
+}

--- a/eddist-admin/src/services/authed_token_service.rs
+++ b/eddist-admin/src/services/authed_token_service.rs
@@ -1,0 +1,160 @@
+use std::sync::Arc;
+
+use eddist_core::{
+    domain::pubsub_repository::{AuthTokenRevoked, CHANNEL_AUTH_TOKEN_REVOKED},
+    proto::encode_auth_token_revoked,
+    redis_keys::authed_token_suspended_key,
+    utils::is_authed_token_backup_enabled,
+};
+use redis::AsyncCommands as _;
+use uuid::Uuid;
+
+use crate::{
+    auth::AdminIdentity,
+    models::{AuthedToken, DeleteAuthedTokenInput, ListAuthedTokensQuery, PaginatedAuthedTokens},
+    repository::authed_token_repository::{AuthedTokenRepository, ListAuthedTokensParams},
+};
+
+const ALLOWED_SORT_COLUMNS: &[&str] = &["created_at", "authed_at", "last_wrote_at"];
+
+#[async_trait::async_trait]
+pub trait AuthedTokenService: Send + Sync {
+    async fn list_authed_tokens(
+        &self,
+        query: ListAuthedTokensQuery,
+    ) -> anyhow::Result<PaginatedAuthedTokens>;
+    async fn get_authed_token(&self, id: Uuid) -> anyhow::Result<AuthedToken>;
+    async fn delete_authed_token(
+        &self,
+        actor: &AdminIdentity,
+        id: Uuid,
+        options: DeleteAuthedTokenInput,
+    ) -> anyhow::Result<()>;
+    async fn set_require_reauth(&self, id: Uuid) -> anyhow::Result<()>;
+    async fn clear_require_reauth(&self, id: Uuid) -> anyhow::Result<()>;
+    async fn suspend_authed_token(&self, id: Uuid, ttl_seconds: u64) -> anyhow::Result<()>;
+    async fn revoke_authed_token(&self, actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()>;
+}
+
+pub struct AuthedTokenServiceImpl {
+    repo: Arc<dyn AuthedTokenRepository>,
+    redis_conn: redis::aio::ConnectionManager,
+}
+
+impl AuthedTokenServiceImpl {
+    pub fn new(
+        repo: Arc<dyn AuthedTokenRepository>,
+        redis_conn: redis::aio::ConnectionManager,
+    ) -> Self {
+        Self { repo, redis_conn }
+    }
+
+    async fn publish_token_revoked(&self, id: Uuid) {
+        let payload = encode_auth_token_revoked(&AuthTokenRevoked {
+            authed_token_id: id,
+        });
+        let mut conn = self.redis_conn.clone();
+        let _: Result<(), _> = conn.publish(CHANNEL_AUTH_TOKEN_REVOKED, payload).await;
+    }
+}
+
+#[async_trait::async_trait]
+impl AuthedTokenService for AuthedTokenServiceImpl {
+    async fn list_authed_tokens(
+        &self,
+        query: ListAuthedTokensQuery,
+    ) -> anyhow::Result<PaginatedAuthedTokens> {
+        let page = query.page.unwrap_or(1).max(1);
+        let per_page = query.per_page.unwrap_or(50).clamp(1, 100);
+        let offset = (page - 1) as u64 * per_page as u64;
+        let sort_column = query
+            .sort_by
+            .as_deref()
+            .filter(|s| ALLOWED_SORT_COLUMNS.contains(s))
+            .unwrap_or("created_at");
+        let sort_asc = query
+            .sort_order
+            .as_deref()
+            .map(|s| s == "asc")
+            .unwrap_or(false);
+
+        let (items, total) = self
+            .repo
+            .list_authed_tokens(ListAuthedTokensParams {
+                offset,
+                limit: per_page,
+                origin_ip: query.origin_ip.as_deref(),
+                writing_ua: query.writing_ua.as_deref(),
+                authed_ua: query.authed_ua.as_deref(),
+                asn_num: query.asn_num,
+                validity: query.validity,
+                sort_column,
+                sort_asc,
+            })
+            .await?;
+
+        let total_pages = ((total as f64) / (per_page as f64)).ceil() as u32;
+        Ok(PaginatedAuthedTokens {
+            items,
+            total,
+            page,
+            per_page,
+            total_pages,
+        })
+    }
+
+    async fn get_authed_token(&self, id: Uuid) -> anyhow::Result<AuthedToken> {
+        self.repo.get_authed_token(id).await
+    }
+
+    async fn delete_authed_token(
+        &self,
+        _actor: &AdminIdentity,
+        id: Uuid,
+        options: DeleteAuthedTokenInput,
+    ) -> anyhow::Result<()> {
+        let affected_ids = if !options.using_origin_ip {
+            self.repo.delete_authed_token(id).await?;
+            vec![id]
+        } else {
+            self.repo.delete_authed_token_by_origin_ip(id).await?
+        };
+
+        if is_authed_token_backup_enabled() {
+            for affected_id in affected_ids {
+                self.publish_token_revoked(affected_id).await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn set_require_reauth(&self, id: Uuid) -> anyhow::Result<()> {
+        self.repo.set_require_reauth(id).await
+    }
+
+    async fn clear_require_reauth(&self, id: Uuid) -> anyhow::Result<()> {
+        self.repo.clear_require_reauth(id).await
+    }
+
+    async fn suspend_authed_token(&self, id: Uuid, ttl_seconds: u64) -> anyhow::Result<()> {
+        let token = self.repo.get_authed_token(id).await?;
+        if !token.validity {
+            return Err(anyhow::anyhow!(
+                "this token has already been permanently revoked"
+            ));
+        }
+        let key = authed_token_suspended_key(&id.to_string());
+        let mut conn = self.redis_conn.clone();
+        conn.set_ex::<_, _, ()>(&key, "1", ttl_seconds)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    async fn revoke_authed_token(&self, _actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()> {
+        self.repo.delete_authed_token(id).await?;
+        if is_authed_token_backup_enabled() {
+            self.publish_token_revoked(id).await;
+        }
+        Ok(())
+    }
+}

--- a/eddist-admin/src/services/board_service.rs
+++ b/eddist-admin/src/services/board_service.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use crate::{
+    auth::AdminIdentity,
+    models::{Board, BoardInfo, CreateBoardInput, EditBoardInput},
+    repository::admin_board_repository::AdminBoardRepository,
+};
+
+#[async_trait::async_trait]
+pub trait BoardService: Send + Sync {
+    async fn get_boards(&self, keys: Option<Vec<String>>) -> anyhow::Result<Vec<Board>>;
+    async fn get_board_info(&self, board_id: uuid::Uuid) -> anyhow::Result<BoardInfo>;
+    async fn create_board(
+        &self,
+        actor: &AdminIdentity,
+        input: CreateBoardInput,
+    ) -> anyhow::Result<Board>;
+    async fn edit_board(
+        &self,
+        actor: &AdminIdentity,
+        board_key: &str,
+        input: EditBoardInput,
+    ) -> anyhow::Result<Board>;
+}
+
+pub struct BoardServiceImpl {
+    repo: Arc<dyn AdminBoardRepository>,
+}
+
+impl BoardServiceImpl {
+    pub fn new(repo: Arc<dyn AdminBoardRepository>) -> Self {
+        Self { repo }
+    }
+}
+
+#[async_trait::async_trait]
+impl BoardService for BoardServiceImpl {
+    async fn get_boards(&self, keys: Option<Vec<String>>) -> anyhow::Result<Vec<Board>> {
+        self.repo.get_boards_by_key(keys).await
+    }
+
+    async fn get_board_info(&self, board_id: uuid::Uuid) -> anyhow::Result<BoardInfo> {
+        self.repo.get_board_info(board_id).await
+    }
+
+    async fn create_board(
+        &self,
+        _actor: &AdminIdentity,
+        input: CreateBoardInput,
+    ) -> anyhow::Result<Board> {
+        self.repo.create_board(input).await
+    }
+
+    async fn edit_board(
+        &self,
+        _actor: &AdminIdentity,
+        board_key: &str,
+        input: EditBoardInput,
+    ) -> anyhow::Result<Board> {
+        self.repo.edit_board(board_key, input).await
+    }
+}

--- a/eddist-admin/src/services/content_admin_service.rs
+++ b/eddist-admin/src/services/content_admin_service.rs
@@ -1,0 +1,260 @@
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::{
+    auth::AdminIdentity,
+    models::{
+        CaptchaConfig, CreateCaptchaConfigInput, Notice, Terms, UpdateCaptchaConfigInput,
+        idp::{CreateIdpInput, Idp, UpdateIdpInput},
+        server_settings::{ServerSetting, UpsertServerSettingInput},
+    },
+    repository::{
+        captcha_config_repository::CaptchaConfigRepository,
+        idp_repository::IdpAdminRepository,
+        notice_repository::{CreateNoticeInput, NoticeRepository, UpdateNoticeInput},
+        server_settings_repository::ServerSettingsRepository,
+        terms_repository::{TermsRepository, UpdateTermsInput},
+    },
+};
+
+#[async_trait::async_trait]
+pub trait ContentAdminService: Send + Sync {
+    // Notices
+    async fn get_notices(&self, page: u32, limit: u32) -> anyhow::Result<Vec<Notice>>;
+    async fn get_notice(&self, id: Uuid) -> anyhow::Result<Option<Notice>>;
+    async fn create_notice(
+        &self,
+        actor: &AdminIdentity,
+        input: CreateNoticeInput,
+    ) -> anyhow::Result<Notice>;
+    async fn update_notice(
+        &self,
+        actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateNoticeInput,
+    ) -> anyhow::Result<Notice>;
+    async fn delete_notice(&self, actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()>;
+    async fn check_notice_author(
+        &self,
+        actor: &AdminIdentity,
+        id: Uuid,
+    ) -> anyhow::Result<eddist_core::domain::notice::Notice>;
+    // Terms
+    async fn get_terms(&self) -> anyhow::Result<Option<Terms>>;
+    async fn update_terms(
+        &self,
+        actor: &AdminIdentity,
+        input: UpdateTermsInput,
+    ) -> anyhow::Result<Terms>;
+    // Server settings
+    async fn list_server_settings(&self) -> anyhow::Result<Vec<ServerSetting>>;
+    async fn upsert_server_setting(
+        &self,
+        actor: &AdminIdentity,
+        input: UpsertServerSettingInput,
+    ) -> anyhow::Result<ServerSetting>;
+    // IdPs
+    async fn list_idps(&self) -> anyhow::Result<Vec<Idp>>;
+    async fn get_idp(&self, id: Uuid) -> anyhow::Result<Option<Idp>>;
+    async fn create_idp(&self, actor: &AdminIdentity, input: CreateIdpInput)
+    -> anyhow::Result<Idp>;
+    async fn update_idp(
+        &self,
+        actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateIdpInput,
+    ) -> anyhow::Result<Idp>;
+    async fn delete_idp(&self, actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()>;
+    // Captcha configs
+    async fn list_captcha_configs(&self) -> anyhow::Result<Vec<CaptchaConfig>>;
+    async fn get_captcha_config(&self, id: Uuid) -> anyhow::Result<Option<CaptchaConfig>>;
+    async fn create_captcha_config(
+        &self,
+        actor: &AdminIdentity,
+        input: CreateCaptchaConfigInput,
+    ) -> anyhow::Result<CaptchaConfig>;
+    async fn update_captcha_config(
+        &self,
+        actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateCaptchaConfigInput,
+    ) -> anyhow::Result<CaptchaConfig>;
+    async fn delete_captcha_config(&self, actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()>;
+}
+
+pub struct ContentAdminServiceImpl {
+    notice_repo: Arc<dyn NoticeRepository>,
+    terms_repo: Arc<dyn TermsRepository>,
+    server_settings_repo: Arc<dyn ServerSettingsRepository>,
+    idp_repo: Arc<dyn IdpAdminRepository>,
+    captcha_config_repo: Arc<dyn CaptchaConfigRepository>,
+}
+
+impl ContentAdminServiceImpl {
+    pub fn new(
+        notice_repo: Arc<dyn NoticeRepository>,
+        terms_repo: Arc<dyn TermsRepository>,
+        server_settings_repo: Arc<dyn ServerSettingsRepository>,
+        idp_repo: Arc<dyn IdpAdminRepository>,
+        captcha_config_repo: Arc<dyn CaptchaConfigRepository>,
+    ) -> Self {
+        Self {
+            notice_repo,
+            terms_repo,
+            server_settings_repo,
+            idp_repo,
+            captcha_config_repo,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ContentAdminService for ContentAdminServiceImpl {
+    async fn get_notices(&self, page: u32, limit: u32) -> anyhow::Result<Vec<Notice>> {
+        let notices = self.notice_repo.get_notices_paginated(page, limit).await?;
+        Ok(notices.into_iter().map(Notice::from).collect())
+    }
+
+    async fn get_notice(&self, id: Uuid) -> anyhow::Result<Option<Notice>> {
+        Ok(self
+            .notice_repo
+            .get_notice_by_id(id)
+            .await?
+            .map(Notice::from))
+    }
+
+    async fn create_notice(
+        &self,
+        actor: &AdminIdentity,
+        input: CreateNoticeInput,
+    ) -> anyhow::Result<Notice> {
+        let notice = self
+            .notice_repo
+            .create_notice(input, Some(actor.email.clone()))
+            .await?;
+        Ok(notice.into())
+    }
+
+    async fn update_notice(
+        &self,
+        _actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateNoticeInput,
+    ) -> anyhow::Result<Notice> {
+        let notice = self.notice_repo.update_notice(id, input).await?;
+        Ok(notice.into())
+    }
+
+    async fn delete_notice(&self, _actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()> {
+        self.notice_repo.delete_notice(id).await
+    }
+
+    async fn check_notice_author(
+        &self,
+        actor: &AdminIdentity,
+        id: Uuid,
+    ) -> anyhow::Result<eddist_core::domain::notice::Notice> {
+        let notice = self
+            .notice_repo
+            .get_notice_by_id(id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Notice not found"))?;
+        if notice.author_email.as_ref() != Some(&actor.email) {
+            return Err(anyhow::anyhow!(
+                "Forbidden: you can only modify notices you created"
+            ));
+        }
+        Ok(notice)
+    }
+
+    async fn get_terms(&self) -> anyhow::Result<Option<Terms>> {
+        Ok(self.terms_repo.get_terms().await?.map(Terms::from))
+    }
+
+    async fn update_terms(
+        &self,
+        actor: &AdminIdentity,
+        input: UpdateTermsInput,
+    ) -> anyhow::Result<Terms> {
+        let terms = self
+            .terms_repo
+            .update_terms(input, Some(actor.email.clone()))
+            .await?;
+        Ok(terms.into())
+    }
+
+    async fn list_server_settings(&self) -> anyhow::Result<Vec<ServerSetting>> {
+        self.server_settings_repo.get_all().await
+    }
+
+    async fn upsert_server_setting(
+        &self,
+        _actor: &AdminIdentity,
+        input: UpsertServerSettingInput,
+    ) -> anyhow::Result<ServerSetting> {
+        self.server_settings_repo.upsert(input).await
+    }
+
+    async fn list_idps(&self) -> anyhow::Result<Vec<Idp>> {
+        self.idp_repo.get_all().await
+    }
+
+    async fn get_idp(&self, id: Uuid) -> anyhow::Result<Option<Idp>> {
+        self.idp_repo.get_by_id(id).await
+    }
+
+    async fn create_idp(
+        &self,
+        _actor: &AdminIdentity,
+        input: CreateIdpInput,
+    ) -> anyhow::Result<Idp> {
+        self.idp_repo.create(input).await
+    }
+
+    async fn update_idp(
+        &self,
+        _actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateIdpInput,
+    ) -> anyhow::Result<Idp> {
+        self.idp_repo.update(id, input).await
+    }
+
+    async fn delete_idp(&self, _actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()> {
+        self.idp_repo.delete(id).await
+    }
+
+    async fn list_captcha_configs(&self) -> anyhow::Result<Vec<CaptchaConfig>> {
+        self.captcha_config_repo.get_all().await
+    }
+
+    async fn get_captcha_config(&self, id: Uuid) -> anyhow::Result<Option<CaptchaConfig>> {
+        self.captcha_config_repo.get_by_id(id).await
+    }
+
+    async fn create_captcha_config(
+        &self,
+        actor: &AdminIdentity,
+        input: CreateCaptchaConfigInput,
+    ) -> anyhow::Result<CaptchaConfig> {
+        self.captcha_config_repo
+            .create(input, Some(actor.email.clone()))
+            .await
+    }
+
+    async fn update_captcha_config(
+        &self,
+        actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateCaptchaConfigInput,
+    ) -> anyhow::Result<CaptchaConfig> {
+        self.captcha_config_repo
+            .update(id, input, Some(actor.email.clone()))
+            .await
+    }
+
+    async fn delete_captcha_config(&self, _actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()> {
+        self.captcha_config_repo.delete(id).await
+    }
+}

--- a/eddist-admin/src/services/mod.rs
+++ b/eddist-admin/src/services/mod.rs
@@ -1,0 +1,73 @@
+pub mod archive_service;
+pub mod authed_token_service;
+pub mod board_service;
+pub mod content_admin_service;
+pub mod moderation_service;
+pub mod thread_service;
+pub mod user_service;
+
+use std::sync::Arc;
+
+use crate::{AdminRepos, ContentRepos, ModerationRepos};
+
+use self::{
+    archive_service::{AdminArchiveService, ArchiveServiceImpl},
+    authed_token_service::{AuthedTokenService, AuthedTokenServiceImpl},
+    board_service::{BoardService, BoardServiceImpl},
+    content_admin_service::{ContentAdminService, ContentAdminServiceImpl},
+    moderation_service::{ModerationService, ModerationServiceImpl},
+    thread_service::{ThreadService, ThreadServiceImpl},
+    user_service::{UserService, UserServiceImpl},
+};
+
+/// Container for all domain services. Add to `AppState` to give handlers access.
+#[derive(Clone)]
+pub struct AppServiceContainer {
+    pub board: Arc<dyn BoardService>,
+    pub thread: Arc<dyn ThreadService>,
+    pub archive: Arc<dyn AdminArchiveService>,
+    pub moderation: Arc<dyn ModerationService>,
+    pub authed_token: Arc<dyn AuthedTokenService>,
+    pub user: Arc<dyn UserService>,
+    pub content_admin: Arc<dyn ContentAdminService>,
+}
+
+impl AppServiceContainer {
+    pub fn new(
+        content: ContentRepos,
+        moderation: ModerationRepos,
+        admin: AdminRepos,
+        redis_conn: redis::aio::ConnectionManager,
+    ) -> Self {
+        Self {
+            board: Arc::new(BoardServiceImpl::new(content.board.clone())),
+            thread: Arc::new(ThreadServiceImpl::new(
+                content.thread.clone(),
+                content.response.clone(),
+                redis_conn.clone(),
+            )),
+            archive: Arc::new(ArchiveServiceImpl::new(
+                content.thread.clone(),
+                content.response.clone(),
+                content.archive.clone(),
+            )),
+            moderation: Arc::new(ModerationServiceImpl::new(
+                moderation.ng_word.clone(),
+                moderation.cap.clone(),
+                moderation.user_restriction.clone(),
+            )),
+            authed_token: Arc::new(AuthedTokenServiceImpl::new(
+                moderation.authed_token.clone(),
+                redis_conn,
+            )),
+            user: Arc::new(UserServiceImpl::new(admin.user.clone())),
+            content_admin: Arc::new(ContentAdminServiceImpl::new(
+                admin.notice.clone(),
+                admin.terms.clone(),
+                admin.server_settings.clone(),
+                admin.idp.clone(),
+                admin.captcha_config.clone(),
+            )),
+        }
+    }
+}

--- a/eddist-admin/src/services/moderation_service.rs
+++ b/eddist-admin/src/services/moderation_service.rs
@@ -1,0 +1,215 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use eddist_core::domain::user_restriction::{
+    CreateUserRestrictionRuleInput, UpdateUserRestrictionRuleInput, UserRestrictionRule,
+};
+use uuid::Uuid;
+
+use crate::{
+    auth::AdminIdentity,
+    models::{
+        Cap, CreationCapInput, CreationNgWordInput, NgWord, UpdateCapInput, UpdateNgWordInput,
+    },
+    repository::{
+        cap_repository::CapRepository, ngword_repository::NgWordRepository,
+        user_restriction_repository::UserRestrictionRepository,
+    },
+};
+
+#[async_trait::async_trait]
+pub trait ModerationService: Send + Sync {
+    // NG words
+    async fn get_ng_words(&self) -> anyhow::Result<Vec<NgWord>>;
+    async fn create_ng_word(
+        &self,
+        actor: &AdminIdentity,
+        input: CreationNgWordInput,
+    ) -> anyhow::Result<NgWord>;
+    async fn update_ng_word(
+        &self,
+        actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateNgWordInput,
+    ) -> anyhow::Result<NgWord>;
+    async fn delete_ng_word(&self, actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()>;
+    // Caps
+    async fn get_caps(&self) -> anyhow::Result<Vec<Cap>>;
+    async fn create_cap(
+        &self,
+        actor: &AdminIdentity,
+        input: CreationCapInput,
+    ) -> anyhow::Result<Cap>;
+    async fn update_cap(
+        &self,
+        actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateCapInput,
+    ) -> anyhow::Result<Cap>;
+    async fn delete_cap(&self, actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()>;
+    // Restriction rules
+    async fn get_restriction_rules(&self) -> anyhow::Result<Vec<UserRestrictionRule>>;
+    async fn get_restriction_rule(&self, id: Uuid) -> anyhow::Result<Option<UserRestrictionRule>>;
+    async fn create_restriction_rule(
+        &self,
+        actor: &AdminIdentity,
+        name: String,
+        rule_type: eddist_core::domain::user_restriction::RestrictionRuleType,
+        rule_value: String,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> anyhow::Result<UserRestrictionRule>;
+    async fn update_restriction_rule(
+        &self,
+        actor: &AdminIdentity,
+        input: UpdateUserRestrictionRuleInput,
+    ) -> anyhow::Result<()>;
+    async fn delete_restriction_rule(&self, actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()>;
+}
+
+pub struct ModerationServiceImpl {
+    ng_word_repo: Arc<dyn NgWordRepository>,
+    cap_repo: Arc<dyn CapRepository>,
+    user_restriction_repo: Arc<dyn UserRestrictionRepository>,
+}
+
+impl ModerationServiceImpl {
+    pub fn new(
+        ng_word_repo: Arc<dyn NgWordRepository>,
+        cap_repo: Arc<dyn CapRepository>,
+        user_restriction_repo: Arc<dyn UserRestrictionRepository>,
+    ) -> Self {
+        Self {
+            ng_word_repo,
+            cap_repo,
+            user_restriction_repo,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ModerationService for ModerationServiceImpl {
+    async fn get_ng_words(&self) -> anyhow::Result<Vec<NgWord>> {
+        self.ng_word_repo.get_ng_words().await
+    }
+
+    async fn create_ng_word(
+        &self,
+        _actor: &AdminIdentity,
+        input: CreationNgWordInput,
+    ) -> anyhow::Result<NgWord> {
+        self.ng_word_repo
+            .create_ng_word(&input.name, &input.word)
+            .await
+    }
+
+    async fn update_ng_word(
+        &self,
+        _actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateNgWordInput,
+    ) -> anyhow::Result<NgWord> {
+        self.ng_word_repo
+            .update_ng_word(
+                id,
+                input.name.as_deref(),
+                input.word.as_deref(),
+                input.board_ids,
+            )
+            .await
+    }
+
+    async fn delete_ng_word(&self, _actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()> {
+        self.ng_word_repo.delete_ng_word(id).await
+    }
+
+    async fn get_caps(&self) -> anyhow::Result<Vec<Cap>> {
+        self.cap_repo.get_caps().await
+    }
+
+    async fn create_cap(
+        &self,
+        _actor: &AdminIdentity,
+        input: CreationCapInput,
+    ) -> anyhow::Result<Cap> {
+        let tinker_secret = std::env::var("TINKER_SECRET")
+            .map_err(|_| anyhow::anyhow!("TINKER_SECRET not configured"))?;
+        self.cap_repo
+            .create_cap(
+                &input.name,
+                &input.description,
+                &eddist_core::domain::cap::calculate_cap_hash(&input.password, &tinker_secret),
+            )
+            .await
+    }
+
+    async fn update_cap(
+        &self,
+        _actor: &AdminIdentity,
+        id: Uuid,
+        input: UpdateCapInput,
+    ) -> anyhow::Result<Cap> {
+        let hashed_password = input.password.map(|p| {
+            let secret = std::env::var("TINKER_SECRET").unwrap_or_default();
+            eddist_core::domain::cap::calculate_cap_hash(&p, &secret)
+        });
+        self.cap_repo
+            .update_cap(
+                id,
+                input.name.as_deref(),
+                input.description.as_deref(),
+                hashed_password.as_deref(),
+                input.board_ids,
+            )
+            .await
+    }
+
+    async fn delete_cap(&self, _actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()> {
+        self.cap_repo.delete_cap(id).await
+    }
+
+    async fn get_restriction_rules(&self) -> anyhow::Result<Vec<UserRestrictionRule>> {
+        Ok(self
+            .user_restriction_repo
+            .get_all_rules()
+            .await
+            .unwrap_or_default())
+    }
+
+    async fn get_restriction_rule(&self, id: Uuid) -> anyhow::Result<Option<UserRestrictionRule>> {
+        self.user_restriction_repo.get_rule_by_id(id).await
+    }
+
+    async fn create_restriction_rule(
+        &self,
+        actor: &AdminIdentity,
+        name: String,
+        rule_type: eddist_core::domain::user_restriction::RestrictionRuleType,
+        rule_value: String,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> anyhow::Result<UserRestrictionRule> {
+        let input = CreateUserRestrictionRuleInput {
+            name,
+            rule_type,
+            rule_value,
+            expires_at,
+            created_by_email: actor.email.clone(),
+        };
+        self.user_restriction_repo.create_rule(input).await
+    }
+
+    async fn update_restriction_rule(
+        &self,
+        _actor: &AdminIdentity,
+        input: UpdateUserRestrictionRuleInput,
+    ) -> anyhow::Result<()> {
+        self.user_restriction_repo.update_rule(input).await
+    }
+
+    async fn delete_restriction_rule(
+        &self,
+        _actor: &AdminIdentity,
+        id: Uuid,
+    ) -> anyhow::Result<()> {
+        self.user_restriction_repo.delete_rule(id).await
+    }
+}

--- a/eddist-admin/src/services/thread_service.rs
+++ b/eddist-admin/src/services/thread_service.rs
@@ -1,0 +1,141 @@
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::{
+    auth::AdminIdentity,
+    models::{Res, Thread, UpdateResInput},
+    repository::{
+        admin_response_repository::AdminResponseRepository,
+        admin_thread_repository::AdminThreadRepository,
+    },
+};
+
+#[async_trait::async_trait]
+pub trait ThreadService: Send + Sync {
+    async fn get_threads(&self, board_key: &str) -> anyhow::Result<Vec<Thread>>;
+    async fn get_thread(&self, board_key: &str, thread_id: u64) -> anyhow::Result<Option<Thread>>;
+    async fn get_responses(&self, board_key: &str, thread_id: u64) -> anyhow::Result<Vec<Res>>;
+    async fn update_response(
+        &self,
+        actor: &AdminIdentity,
+        board_key: &str,
+        thread_id: u64,
+        res_id: Uuid,
+        input: UpdateResInput,
+    ) -> anyhow::Result<Res>;
+    async fn compact_threads(
+        &self,
+        actor: &AdminIdentity,
+        board_key: &str,
+        target_count: u32,
+    ) -> anyhow::Result<()>;
+}
+
+pub struct ThreadServiceImpl {
+    thread_repo: Arc<dyn AdminThreadRepository>,
+    response_repo: Arc<dyn AdminResponseRepository>,
+    redis_conn: redis::aio::ConnectionManager,
+}
+
+impl ThreadServiceImpl {
+    pub fn new(
+        thread_repo: Arc<dyn AdminThreadRepository>,
+        response_repo: Arc<dyn AdminResponseRepository>,
+        redis_conn: redis::aio::ConnectionManager,
+    ) -> Self {
+        Self {
+            thread_repo,
+            response_repo,
+            redis_conn,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ThreadService for ThreadServiceImpl {
+    async fn get_threads(&self, board_key: &str) -> anyhow::Result<Vec<Thread>> {
+        self.thread_repo
+            .get_threads_by_thread_id(board_key, None)
+            .await
+    }
+
+    async fn get_thread(&self, board_key: &str, thread_id: u64) -> anyhow::Result<Option<Thread>> {
+        let threads = self
+            .thread_repo
+            .get_threads_by_thread_id(board_key, Some(vec![thread_id]))
+            .await?;
+        Ok(threads.into_iter().next())
+    }
+
+    async fn get_responses(&self, board_key: &str, thread_id: u64) -> anyhow::Result<Vec<Res>> {
+        self.response_repo
+            .get_reses_by_thread_id(board_key, thread_id)
+            .await
+    }
+
+    async fn update_response(
+        &self,
+        _actor: &AdminIdentity,
+        board_key: &str,
+        _thread_id: u64,
+        res_id: Uuid,
+        input: UpdateResInput,
+    ) -> anyhow::Result<Res> {
+        use eddist_core::domain::res::ResView;
+
+        let (res, default_name, board_key_actual, thread_number, thread_title) =
+            self.response_repo.get_res(res_id).await?;
+
+        let updated_res = self
+            .response_repo
+            .update_res(
+                res_id,
+                input.author_name.clone(),
+                input.mail.clone(),
+                input.body.clone(),
+                input.is_abone,
+            )
+            .await?;
+
+        let author_name = input
+            .author_name
+            .unwrap_or_else(|| res.author_name.unwrap_or(default_name.clone()));
+        let mail = input.mail.unwrap_or_default();
+        let is_abone = input.is_abone.unwrap_or(res.is_abone);
+        let body = input.body.unwrap_or(res.body);
+
+        let res_view = ResView {
+            author_name,
+            mail,
+            body,
+            created_at: res.created_at,
+            author_id: res.author_id,
+            is_abone,
+        };
+        let res_view = res_view.get_sjis_bytes(&default_name, thread_title.as_deref());
+
+        let _ = board_key; // use the board_key from the actual DB record
+        let mut conn = self.redis_conn.clone();
+        let _ = conn
+            .send_packed_command(&redis::Cmd::lset(
+                format!("threads:{}:{}", board_key_actual, thread_number),
+                res.res_order as isize - 1,
+                res_view.get_inner(),
+            ))
+            .await;
+
+        Ok(updated_res)
+    }
+
+    async fn compact_threads(
+        &self,
+        _actor: &AdminIdentity,
+        board_key: &str,
+        target_count: u32,
+    ) -> anyhow::Result<()> {
+        self.thread_repo
+            .compact_threads(board_key, target_count)
+            .await
+    }
+}

--- a/eddist-admin/src/services/user_service.rs
+++ b/eddist-admin/src/services/user_service.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::{
+    auth::AdminIdentity,
+    models::{User, UserSearchQuery},
+    repository::admin_user_repository::AdminUserRepository,
+};
+
+#[async_trait::async_trait]
+pub trait UserService: Send + Sync {
+    async fn search_users(&self, query: UserSearchQuery) -> anyhow::Result<Vec<User>>;
+    async fn update_user_status(
+        &self,
+        actor: &AdminIdentity,
+        user_id: Uuid,
+        enabled: bool,
+    ) -> anyhow::Result<User>;
+}
+
+pub struct UserServiceImpl {
+    repo: Arc<dyn AdminUserRepository>,
+}
+
+impl UserServiceImpl {
+    pub fn new(repo: Arc<dyn AdminUserRepository>) -> Self {
+        Self { repo }
+    }
+}
+
+#[async_trait::async_trait]
+impl UserService for UserServiceImpl {
+    async fn search_users(&self, query: UserSearchQuery) -> anyhow::Result<Vec<User>> {
+        self.repo
+            .search_users(query.user_id, query.user_name, query.authed_token_id)
+            .await
+    }
+
+    async fn update_user_status(
+        &self,
+        _actor: &AdminIdentity,
+        user_id: Uuid,
+        enabled: bool,
+    ) -> anyhow::Result<User> {
+        self.repo.update_user_status(user_id, enabled).await?;
+        let users = self.repo.search_users(Some(user_id), None, None).await?;
+        users
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("User not found after update"))
+    }
+}

--- a/eddist-admin/src/utils.rs
+++ b/eddist-admin/src/utils.rs
@@ -1,0 +1,27 @@
+use sqlx::{Database, Transaction};
+
+#[async_trait::async_trait]
+pub trait TransactionRepository<T: Database> {
+    async fn begin(&self) -> anyhow::Result<Transaction<'_, T>>;
+}
+
+/// Implement `TransactionRepository<DB>` for a repository struct that holds a pool as a named
+/// field (`$conn`) or index (`0`).
+///
+/// Usage:
+/// ```ignore
+/// transaction_repository!(AdminBoardRepositoryImpl, 0, MySql);
+/// transaction_repository!(UserRestrictionRepositoryImpl, pool, MySql);
+/// ```
+#[macro_export]
+macro_rules! transaction_repository {
+    ($impl_struct:ident, $conn:tt, $database:ident) => {
+        #[async_trait::async_trait]
+        impl $crate::utils::TransactionRepository<sqlx::$database> for $impl_struct {
+            async fn begin(&self) -> anyhow::Result<sqlx::Transaction<'_, sqlx::$database>> {
+                let tx = self.$conn.begin().await?;
+                Ok(tx)
+            }
+        }
+    };
+}


### PR DESCRIPTION
- Remove unused allow(dead_code) attributes and clean up dead code
- Remove AdminEmail extractor, replace with AdminIdentity throughout
- Remove unused get_admin_email() method from AdminSession
- Remove unused redis_conn field from AppState (now encapsulated in services)
- Standardize auth.rs logging from log:: to tracing::
- All mutating handlers now extract AdminIdentity to track actor for audit logging
