### PR TITLE
refactor: improve eddist-admin error handling with typed ServiceError

### DIFF
--- a/eddist-admin/src/error.rs
+++ b/eddist-admin/src/error.rs
@@ -5,6 +5,24 @@ use axum::{
 };
 use serde_json::json;
 
+/// Typed errors produced by service and repository layer to convey semantic meaning.
+/// Wrapping these in `anyhow::Error` lets the `From<anyhow::Error> for ApiError`
+/// impl downcast them automatically, so route handlers can just use `?`.
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum ServiceError {
+    #[error("{0}")]
+    NotFound(String),
+
+    #[error("{0}")]
+    Forbidden(String),
+
+    #[error("{0}")]
+    BadRequest(String),
+
+    #[error("{0}")]
+    ConfigError(String),
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum ApiError {
     #[error("Not found: {0}")]
@@ -20,7 +38,7 @@ pub enum ApiError {
     Forbidden(String),
 
     #[error(transparent)]
-    Internal(#[from] anyhow::Error),
+    Internal(anyhow::Error),
 }
 
 impl ApiError {
@@ -38,6 +56,26 @@ impl ApiError {
 
     pub fn forbidden(msg: impl Into<String>) -> Self {
         Self::Forbidden(msg.into())
+    }
+}
+
+impl From<anyhow::Error> for ApiError {
+    fn from(e: anyhow::Error) -> Self {
+        // Walk the full source chain so that ServiceErrors wrapped with .context() are still found.
+        // downcast_ref on anyhow::Error alone only matches the outermost error.
+        let service_err = e
+            .chain()
+            .find_map(|cause| cause.downcast_ref::<ServiceError>());
+        match service_err {
+            Some(ServiceError::NotFound(msg)) => ApiError::NotFound(msg.clone()),
+            Some(ServiceError::Forbidden(msg)) => ApiError::Forbidden(msg.clone()),
+            Some(ServiceError::BadRequest(msg)) => ApiError::BadRequest(msg.clone()),
+            Some(ServiceError::ConfigError(_)) => {
+                tracing::error!("Configuration error: {e:?}");
+                ApiError::Internal(e)
+            }
+            None => ApiError::Internal(e),
+        }
     }
 }
 

--- a/eddist-admin/src/repository/authed_token_repository.rs
+++ b/eddist-admin/src/repository/authed_token_repository.rs
@@ -103,8 +103,9 @@ impl AuthedTokenRepository for AuthedTokenRepositoryImpl {
             "#,
             id.as_bytes().to_vec(),
         )
-        .fetch_one(&self.0)
-        .await?;
+        .fetch_optional(&self.0)
+        .await?
+        .ok_or_else(|| crate::error::ServiceError::NotFound("Authed token not found".into()))?;
 
         Ok(AuthedToken::from(row))
     }

--- a/eddist-admin/src/repository/captcha_config_repository.rs
+++ b/eddist-admin/src/repository/captcha_config_repository.rs
@@ -299,10 +299,9 @@ impl CaptchaConfigRepository for CaptchaConfigRepositoryImpl {
     ) -> anyhow::Result<CaptchaConfig> {
         let now = Utc::now().naive_utc();
 
-        let current = self
-            .get_by_id(id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Captcha config not found"))?;
+        let current = self.get_by_id(id).await?.ok_or_else(|| {
+            crate::error::ServiceError::NotFound("Captcha config not found".into())
+        })?;
 
         let name = input.name.unwrap_or(current.name);
         let provider = input.provider.unwrap_or(current.provider);

--- a/eddist-admin/src/repository/idp_repository.rs
+++ b/eddist-admin/src/repository/idp_repository.rs
@@ -110,7 +110,7 @@ impl IdpAdminRepository for IdpAdminRepositoryImpl {
         let current = self
             .get_by_id(id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("IdP not found"))?;
+            .ok_or_else(|| crate::error::ServiceError::NotFound("IdP not found".into()))?;
 
         let idp_display_name = input.idp_display_name.unwrap_or(current.idp_display_name);
         let idp_logo_svg = if input.idp_logo_svg.is_some() {

--- a/eddist-admin/src/repository/notice_repository.rs
+++ b/eddist-admin/src/repository/notice_repository.rs
@@ -175,7 +175,7 @@ impl NoticeRepository for NoticeRepositoryImpl {
         let current = self
             .get_notice_by_id(id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("Notice not found"))?;
+            .ok_or_else(|| crate::error::ServiceError::NotFound("Notice not found".into()))?;
 
         let title = input.title.clone().unwrap_or_else(|| current.title.clone());
         let content = input.content.unwrap_or(current.content);

--- a/eddist-admin/src/repository/terms_repository.rs
+++ b/eddist-admin/src/repository/terms_repository.rs
@@ -61,7 +61,7 @@ impl TermsRepository for TermsRepositoryImpl {
         let current = self
             .get_terms()
             .await?
-            .ok_or_else(|| anyhow::anyhow!("Terms not found"))?;
+            .ok_or_else(|| crate::error::ServiceError::NotFound("Terms not found".into()))?;
 
         query!(
             r#"

--- a/eddist-admin/src/routes/captcha.rs
+++ b/eddist-admin/src/routes/captcha.rs
@@ -82,8 +82,7 @@ pub async fn create_captcha_config(
         .services
         .content_admin
         .create_captcha_config(&identity, input)
-        .await
-        .map_err(|e| ApiError::bad_request(format!("Failed to create captcha config: {e}")))?;
+        .await?;
     Ok((StatusCode::CREATED, Json(config)))
 }
 
@@ -112,14 +111,7 @@ pub async fn update_captcha_config(
         .services
         .content_admin
         .update_captcha_config(&identity, id, input)
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("not found") {
-                ApiError::not_found("Captcha config not found")
-            } else {
-                ApiError::bad_request(format!("Failed to update captcha config: {e}"))
-            }
-        })?;
+        .await?;
     Ok(Json(config))
 }
 
@@ -145,7 +137,6 @@ pub async fn delete_captcha_config(
         .services
         .content_admin
         .delete_captcha_config(&identity, id)
-        .await
-        .map_err(|e| ApiError::not_found(format!("Failed to delete captcha config: {e}")))?;
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/eddist-admin/src/routes/idps.rs
+++ b/eddist-admin/src/routes/idps.rs
@@ -79,8 +79,7 @@ pub async fn create_idp(
         .services
         .content_admin
         .create_idp(&identity, input)
-        .await
-        .map_err(|e| ApiError::bad_request(format!("Failed to create IdP: {e}")))?;
+        .await?;
     Ok((StatusCode::CREATED, Json(idp)))
 }
 
@@ -108,14 +107,7 @@ pub async fn update_idp(
         .services
         .content_admin
         .update_idp(&identity, id, input)
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("not found") {
-                ApiError::not_found("IdP not found")
-            } else {
-                ApiError::bad_request(format!("Failed to update IdP: {e}"))
-            }
-        })?;
+        .await?;
     Ok(Json(idp))
 }
 
@@ -140,7 +132,6 @@ pub async fn delete_idp(
         .services
         .content_admin
         .delete_idp(&identity, id)
-        .await
-        .map_err(|e| ApiError::not_found(format!("Failed to delete IdP: {e}")))?;
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/eddist-admin/src/routes/internal.rs
+++ b/eddist-admin/src/routes/internal.rs
@@ -34,16 +34,7 @@ pub async fn suspend_authed_token(
         .services
         .authed_token
         .suspend_authed_token(input.authed_token_id, input.ttl_seconds)
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("not found") {
-                ApiError::not_found("authed token not found")
-            } else if e.to_string().contains("permanently revoked") {
-                ApiError::bad_request(e.to_string())
-            } else {
-                ApiError::Internal(e)
-            }
-        })?;
+        .await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/eddist-admin/src/routes/notices.rs
+++ b/eddist-admin/src/routes/notices.rs
@@ -103,8 +103,7 @@ pub async fn create_notice(
         .services
         .content_admin
         .create_notice(&identity, input)
-        .await
-        .map_err(|e| ApiError::bad_request(format!("Failed to create notice: {e}")))?;
+        .await?;
     Ok((StatusCode::CREATED, Json(notice)))
 }
 
@@ -133,14 +132,7 @@ pub async fn update_notice(
         .services
         .content_admin
         .check_notice_author(&identity, id)
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("Forbidden") {
-                ApiError::forbidden(e.to_string())
-            } else {
-                ApiError::not_found(e.to_string())
-            }
-        })?;
+        .await?;
 
     if matches!(&input.slug, Some(slug) if slug == "latest") {
         return Err(ApiError::bad_request("'latest' is a reserved slug"));
@@ -150,14 +142,7 @@ pub async fn update_notice(
         .services
         .content_admin
         .update_notice(&identity, id, input)
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("not found") {
-                ApiError::not_found("Notice not found")
-            } else {
-                ApiError::bad_request(format!("Failed to update notice: {e}"))
-            }
-        })?;
+        .await?;
     Ok(Json(notice))
 }
 
@@ -183,20 +168,12 @@ pub async fn delete_notice(
         .services
         .content_admin
         .check_notice_author(&identity, id)
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("Forbidden") {
-                ApiError::forbidden(e.to_string())
-            } else {
-                ApiError::not_found(e.to_string())
-            }
-        })?;
+        .await?;
 
     state
         .services
         .content_admin
         .delete_notice(&identity, id)
-        .await
-        .map_err(|e| ApiError::not_found(format!("Failed to delete notice: {e}")))?;
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/eddist-admin/src/routes/terms.rs
+++ b/eddist-admin/src/routes/terms.rs
@@ -53,13 +53,6 @@ pub async fn update_terms(
         .services
         .content_admin
         .update_terms(&identity, input)
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("not found") {
-                ApiError::not_found("Terms not found")
-            } else {
-                ApiError::bad_request(format!("Failed to update terms: {e}"))
-            }
-        })?;
+        .await?;
     Ok(Json(terms))
 }

--- a/eddist-admin/src/services/authed_token_service.rs
+++ b/eddist-admin/src/services/authed_token_service.rs
@@ -139,9 +139,10 @@ impl AuthedTokenService for AuthedTokenServiceImpl {
     async fn suspend_authed_token(&self, id: Uuid, ttl_seconds: u64) -> anyhow::Result<()> {
         let token = self.repo.get_authed_token(id).await?;
         if !token.validity {
-            return Err(anyhow::anyhow!(
-                "this token has already been permanently revoked"
-            ));
+            return Err(crate::error::ServiceError::BadRequest(
+                "this token has already been permanently revoked".into(),
+            )
+            .into());
         }
         let key = authed_token_suspended_key(&id.to_string());
         let mut conn = self.redis_conn.clone();

--- a/eddist-admin/src/services/content_admin_service.rs
+++ b/eddist-admin/src/services/content_admin_service.rs
@@ -159,11 +159,12 @@ impl ContentAdminService for ContentAdminServiceImpl {
             .notice_repo
             .get_notice_by_id(id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("Notice not found"))?;
+            .ok_or_else(|| crate::error::ServiceError::NotFound("Notice not found".into()))?;
         if notice.author_email.as_ref() != Some(&actor.email) {
-            return Err(anyhow::anyhow!(
-                "Forbidden: you can only modify notices you created"
-            ));
+            return Err(crate::error::ServiceError::Forbidden(
+                "you can only modify notices you created".into(),
+            )
+            .into());
         }
         Ok(notice)
     }

--- a/eddist-admin/src/services/moderation_service.rs
+++ b/eddist-admin/src/services/moderation_service.rs
@@ -131,8 +131,9 @@ impl ModerationService for ModerationServiceImpl {
         _actor: &AdminIdentity,
         input: CreationCapInput,
     ) -> anyhow::Result<Cap> {
-        let tinker_secret = std::env::var("TINKER_SECRET")
-            .map_err(|_| anyhow::anyhow!("TINKER_SECRET not configured"))?;
+        let tinker_secret = std::env::var("TINKER_SECRET").map_err(|_| {
+            crate::error::ServiceError::ConfigError("TINKER_SECRET not configured".into())
+        })?;
         self.cap_repo
             .create_cap(
                 &input.name,

--- a/eddist-admin/src/services/user_service.rs
+++ b/eddist-admin/src/services/user_service.rs
@@ -45,9 +45,8 @@ impl UserService for UserServiceImpl {
     ) -> anyhow::Result<User> {
         self.repo.update_user_status(user_id, enabled).await?;
         let users = self.repo.search_users(Some(user_id), None, None).await?;
-        users
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("User not found after update"))
+        users.into_iter().next().ok_or_else(|| {
+            crate::error::ServiceError::NotFound("User not found after update".into()).into()
+        })
     }
 }


### PR DESCRIPTION
- Add ServiceError enum (NotFound, Forbidden, BadRequest, ConfigError) for semantic error categorization in service/repository layers
- Implement From<anyhow::Error> for ApiError that downcasts ServiceError by walking the full error chain (not just outermost), preserving errors wrapped with .context()
- Replace route-level error string-matching with typed downcasting for correct HTTP status codes (400/403/404/500)
- Simplify route handlers by removing fragile map_err blocks
- Update repositories (captcha_config, idp, notice, terms, authed_token, user) to throw typed ServiceError instead of generic anyhow::anyhow!()
- Restore diagnostic specificity in user_service error message