### PR TITLE
fix: correct abone response line parsing in eddist-client-v2

### DIFF
--- a/eddist-server/client-v2/app/api-client/thread.ts
+++ b/eddist-server/client-v2/app/api-client/thread.ts
@@ -90,7 +90,7 @@ const convertThreadTextToResponseList = (text: string) => {
     const match = line.match(lineRegex);
     if (match == null) {
       // あぼーん<>あぼーん<><> あぼーん<> てす
-      const aboneRegex = /^(.*)<>(.*)<><> あぼーん<>(.*)$/;
+      const aboneRegex = /^(.*)<>(.*)<><> あぼーん <>(.*)$/;
       const aboneMatch = line.match(aboneRegex);
       if (aboneMatch == null) {
         // 1001 stopper line: "1001<><>Over 1000 Thread<>{body}<>"


### PR DESCRIPTION
- Add missing trailing space in abone regex pattern
- Abone lines output as 'あぼーん <>' but regex was matching '<>'
- Fixes parsing error when threads contain deleted responses
