### PR TITLE
feat: add AI thread summarization using Chrome Summarizer API

### DIFF
--- a/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
+++ b/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
@@ -13,6 +13,9 @@ interface NGWordsSettingsModalProps {
   open: boolean;
   setOpen: (open: boolean) => void;
   enableSafeMode: boolean;
+  summarizerSupported?: boolean;
+  summarizeEnabled?: boolean;
+  onSummarizeEnabledChange?: (enabled: boolean) => void;
 }
 
 const ThemeTab = () => {
@@ -91,10 +94,50 @@ const SafeModeTab = () => {
   );
 };
 
+const SummarizeTab = ({
+  enabled,
+  onChange,
+}: {
+  enabled: boolean;
+  onChange: (v: boolean) => void;
+}) => (
+  <div className="py-2 dark:text-gray-100">
+    <h3 className="text-lg font-semibold mb-2">スレッド要約</h3>
+    <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      ONのとき、スレッド一覧にAI要約ボタンを表示します。ChromiumベースのブラウザのSummarizer
+      APIを使用します。初回使用時にAIモデルの大容量データ（数GB）がダウンロードされる場合があります。モバイル回線などでのご利用はご注意ください。
+    </p>
+    <label className="flex items-center gap-3 cursor-pointer select-none">
+      <div className="relative">
+        <input
+          type="checkbox"
+          className="sr-only"
+          checked={enabled}
+          onChange={() => onChange(!enabled)}
+        />
+        <div
+          className={`w-11 h-6 rounded-full transition-colors ${
+            enabled ? "bg-blue-600" : "bg-gray-300 dark:bg-gray-600"
+          }`}
+        />
+        <div
+          className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+            enabled ? "translate-x-5" : ""
+          }`}
+        />
+      </div>
+      <span className="font-medium">スレッド要約: {enabled ? "ON" : "OFF"}</span>
+    </label>
+  </div>
+);
+
 export const NGWordsSettingsModal = ({
   open,
   setOpen,
   enableSafeMode,
+  summarizerSupported,
+  summarizeEnabled = false,
+  onSummarizeEnabledChange,
 }: NGWordsSettingsModalProps) => {
   const { config, addRule, updateRule, removeRule, toggleRule, clearAllRules } = useNGWords();
 
@@ -179,6 +222,20 @@ export const NGWordsSettingsModal = ({
             },
             ...(enableSafeMode
               ? [{ id: "safe-mode", title: "セーフモード", content: <SafeModeTab /> }]
+              : []),
+            ...(summarizerSupported
+              ? [
+                  {
+                    id: "summarize",
+                    title: "要約",
+                    content: (
+                      <SummarizeTab
+                        enabled={summarizeEnabled}
+                        onChange={onSummarizeEnabledChange ?? (() => {})}
+                      />
+                    ),
+                  },
+                ]
               : []),
           ]}
         />

--- a/eddist-server/client-v2/app/components/ThreadSummarizeButton.tsx
+++ b/eddist-server/client-v2/app/components/ThreadSummarizeButton.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { FaMagic, FaSync } from "react-icons/fa";
+import { fetchThread } from "~/api-client/thread";
+
+interface Props {
+  boardKey: string;
+  threadId: number;
+  threadTitle: string;
+}
+
+type State = "idle" | "loading" | "done" | "error";
+
+const stripHtml = (html: string) =>
+  html
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&")
+    .replace(/&nbsp;/g, " ")
+    .trim();
+
+const fitToQuota = async (summarizer: Summarizer, responses: string[]): Promise<string> => {
+  const full = responses.join("\n\n");
+  const usage = await summarizer.measureInputUsage(full);
+  if (usage <= summarizer.inputQuota) return full;
+
+  const ratio = summarizer.inputQuota / usage;
+  let count = Math.max(1, Math.floor(responses.length * ratio * 0.9));
+  let text = responses.slice(0, count).join("\n\n");
+
+  const usage2 = await summarizer.measureInputUsage(text);
+  if (usage2 > summarizer.inputQuota && count > 1) {
+    count = Math.max(1, Math.floor(count * (summarizer.inputQuota / usage2) * 0.9));
+    text = responses.slice(0, count).join("\n\n");
+  }
+
+  return text;
+};
+
+export const ThreadSummarizeButton = ({ boardKey, threadId, threadTitle }: Props) => {
+  const [state, setState] = useState<State>("idle");
+  const [summary, setSummary] = useState<string | null>(null);
+  const [showPopover, setShowPopover] = useState(false);
+  const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!showPopover) return;
+    const close = (e: MouseEvent) => {
+      if (!buttonRef.current?.contains(e.target as Node)) {
+        setShowPopover(false);
+      }
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [showPopover]);
+
+  const computePopoverStyle = (): React.CSSProperties => {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (!rect) return {};
+    const popoverWidth = 320;
+    const left = Math.max(
+      8,
+      Math.min(rect.left + window.scrollX, window.innerWidth - popoverWidth - 8),
+    );
+    if (rect.top > 220) {
+      return {
+        position: "absolute",
+        top: rect.top + window.scrollY - 8,
+        left,
+        width: popoverWidth,
+        transform: "translateY(-100%)",
+      };
+    }
+    return {
+      position: "absolute",
+      top: rect.bottom + window.scrollY + 8,
+      left,
+      width: popoverWidth,
+    };
+  };
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (state === "done" || state === "error") {
+      setPopoverStyle(computePopoverStyle());
+      setShowPopover((v) => !v);
+      return;
+    }
+
+    setPopoverStyle(computePopoverStyle());
+    setShowPopover(true);
+    setState("loading");
+
+    try {
+      const thread = await fetchThread(boardKey, String(threadId));
+      const plainTitle = stripHtml(threadTitle);
+      const responses = thread.responses
+        .slice(0, 50)
+        .map((r) => stripHtml(r.bodyParts.map((p) => p.text).join("")))
+        .filter(Boolean);
+
+      const availability = await Summarizer.availability();
+      if (availability === "unavailable") throw new Error("Summarizer unavailable");
+
+      const summarizer = await Summarizer.create({
+        type: "key-points",
+        format: "plain-text",
+        length: "short",
+        sharedContext: `日本語の掲示板スレッド「${plainTitle}」`,
+      });
+      const fittedText = await fitToQuota(summarizer, responses);
+      const result = await summarizer.summarize(fittedText);
+      summarizer.destroy();
+
+      setSummary(result);
+      setState("done");
+    } catch (err) {
+      console.error("Summarize error:", err);
+      setState("error");
+      setSummary("要約に失敗しました");
+    }
+  };
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={handleClick}
+        title="要約"
+        disabled={state === "loading"}
+        className={`p-1.5 rounded text-xs transition-colors ${
+          state === "loading"
+            ? "text-gray-400 cursor-wait"
+            : "text-purple-500 hover:text-purple-700 hover:bg-purple-100 dark:hover:bg-purple-900"
+        } ${showPopover ? "bg-purple-100 dark:bg-purple-900" : ""}`}
+      >
+        {state === "loading" ? (
+          <FaSync className="w-3 h-3 animate-spin" />
+        ) : (
+          <FaMagic className="w-3 h-3" />
+        )}
+      </button>
+
+      {showPopover &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            style={popoverStyle}
+            className="z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg p-3 text-sm text-gray-800 dark:text-gray-200"
+          >
+            {state === "loading" ? (
+              <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400">
+                <FaSync className="animate-spin w-3 h-3 shrink-0" />
+                <span>要約中...</span>
+              </div>
+            ) : (
+              <p className="whitespace-pre-wrap leading-relaxed">{summary}</p>
+            )}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+};

--- a/eddist-server/client-v2/app/hooks/useSummarizeEnabled.ts
+++ b/eddist-server/client-v2/app/hooks/useSummarizeEnabled.ts
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+const STORAGE_KEY = "eddist:summarize:enabled";
+
+export const useSummarizeEnabled = () => {
+  const [enabled, setEnabledState] = useState(() => {
+    if (typeof localStorage === "undefined") return false;
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  });
+
+  const setEnabled = (next: boolean) => {
+    localStorage.setItem(STORAGE_KEY, String(next));
+    setEnabledState(next);
+  };
+
+  return { enabled, setEnabled };
+};

--- a/eddist-server/client-v2/app/hooks/useSummarizer.ts
+++ b/eddist-server/client-v2/app/hooks/useSummarizer.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from "react";
+
+export const useSummarizerSupported = (): boolean => {
+  const [supported, setSupported] = useState(false);
+
+  useEffect(() => {
+    setSupported(typeof Summarizer !== "undefined");
+  }, []);
+
+  return supported;
+};

--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -11,9 +11,12 @@ import { fetchThreadList, type Thread } from "~/api-client/thread_list";
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useContextMenu } from "~/hooks/useContextMenu";
 import { usePullToRefresh } from "~/hooks/usePullToRefresh";
+import { useSummarizeEnabled } from "~/hooks/useSummarizeEnabled";
+import { useSummarizerSupported } from "~/hooks/useSummarizer";
 import { parseCookie } from "~/utils/cookie";
 import { getSelectedTextInElement } from "~/utils/selection";
 import { NGContextMenu } from "../components/NGContextMenu";
+import { ThreadSummarizeButton } from "../components/ThreadSummarizeButton";
 import type { Route } from "./+types/ThreadListPage";
 
 const LazyPostThreadModal = lazy(() => import("../components/PostThreadModal"));
@@ -170,6 +173,8 @@ const ThreadListPage = ({
 
   const { shouldFilterThread } = useNGWords();
   const unsafeSet = useMemo(() => new Set(unsafeThreadIds), [unsafeThreadIds]);
+  const summarizerSupported = useSummarizerSupported();
+  const { enabled: summarizeEnabled, setEnabled: setSummarizeEnabled } = useSummarizeEnabled();
   const { menuState, closeMenu, contextMenuHandlers } = useContextMenu();
   const [contextMenuThread, setContextMenuThread] = useState<Thread | null>(null);
   const [selectedTitleText, setSelectedTitleText] = useState<string | null>(null);
@@ -353,6 +358,9 @@ const ThreadListPage = ({
               open={showNGSettings}
               setOpen={setShowNGSettings}
               enableSafeMode={enableSafeMode}
+              summarizerSupported={summarizerSupported}
+              summarizeEnabled={summarizeEnabled}
+              onSummarizeEnabledChange={setSummarizeEnabled}
             />
           </Suspense>
         )}
@@ -448,53 +456,61 @@ const ThreadListPage = ({
             {i !== 0 && (
               <div className="border-b border-gray-400 dark:border-gray-600 lg:border-none lg:pt-2"></div>
             )}
-            <Link
-              to={`/${params.boardKey}/${thread.id}`}
-              className="hover:bg-gray-200 dark:hover:bg-gray-700 cursor-default text-left block w-full bg-gray-100 dark:bg-gray-800 p-2 lg:p-3 select-none md:select-auto"
-              data-ng-target="title"
-              data-ng-thread-id={thread.id}
-              {...contextMenuHandlers}
-              onMouseDown={(e) => {
-                // Capture selection before it gets cleared by right-click
-                if (e.button === 2) {
-                  // Right mouse button
-                  capturedSelectionRef.current = getSelectedTextInElement(e.currentTarget);
-                }
-              }}
-              onContextMenu={(e) => {
-                // Use captured selection from mousedown
-                const selectedText = capturedSelectionRef.current;
-                capturedSelectionRef.current = null; // Clear after use
-                contextMenuHandlers.onContextMenu(e);
-                setContextMenuThread(thread);
-                setSelectedTitleText(selectedText);
-              }}
-              onTouchStart={(e) => {
-                const selectedText = getSelectedTextInElement(e.currentTarget);
-                contextMenuHandlers.onTouchStart(e);
-                setContextMenuThread(thread);
-                setSelectedTitleText(selectedText);
-              }}
-            >
-              <div>
-                <span
-                  className="break-all"
-                  // biome-ignore lint/security/noDangerouslySetInnerHtml: BBS thread title rendered as HTML
-                  dangerouslySetInnerHTML={{
-                    __html: thread.title,
-                  }}
-                />
-                <span> ({thread.responseCount})</span>
-              </div>
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                <span>{convertLinuxTimeToDateString(thread.id)}</span>
-                {thread.authorId && <span>ID:{thread.authorId}</span>}
-                <span className="text-blue-600 font-semibold">
-                  {calculateThreadSpeed(thread.id, thread.responseCount, currentTime)}
-                  /day
-                </span>
-              </div>
-            </Link>
+            <div className="relative bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700">
+              <Link
+                to={`/${params.boardKey}/${thread.id}`}
+                className="cursor-default text-left block w-full p-2 lg:p-3 select-none md:select-auto"
+                data-ng-target="title"
+                data-ng-thread-id={thread.id}
+                {...contextMenuHandlers}
+                onMouseDown={(e) => {
+                  if (e.button === 2) {
+                    capturedSelectionRef.current = getSelectedTextInElement(e.currentTarget);
+                  }
+                }}
+                onContextMenu={(e) => {
+                  const selectedText = capturedSelectionRef.current;
+                  capturedSelectionRef.current = null;
+                  contextMenuHandlers.onContextMenu(e);
+                  setContextMenuThread(thread);
+                  setSelectedTitleText(selectedText);
+                }}
+                onTouchStart={(e) => {
+                  const selectedText = getSelectedTextInElement(e.currentTarget);
+                  contextMenuHandlers.onTouchStart(e);
+                  setContextMenuThread(thread);
+                  setSelectedTitleText(selectedText);
+                }}
+              >
+                <div className={summarizerSupported && summarizeEnabled ? "pr-7" : ""}>
+                  <span
+                    className="break-all"
+                    // biome-ignore lint/security/noDangerouslySetInnerHtml: BBS thread title rendered as HTML
+                    dangerouslySetInnerHTML={{
+                      __html: thread.title,
+                    }}
+                  />
+                  <span> ({thread.responseCount})</span>
+                </div>
+                <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                  <span>{convertLinuxTimeToDateString(thread.id)}</span>
+                  {thread.authorId && <span>ID:{thread.authorId}</span>}
+                  <span className="text-blue-600 font-semibold">
+                    {calculateThreadSpeed(thread.id, thread.responseCount, currentTime)}
+                    /day
+                  </span>
+                </div>
+              </Link>
+              {summarizerSupported && summarizeEnabled && (
+                <div className="absolute top-2 right-2">
+                  <ThreadSummarizeButton
+                    boardKey={params.boardKey ?? ""}
+                    threadId={thread.id}
+                    threadTitle={thread.title}
+                  />
+                </div>
+              )}
+            </div>
           </div>
         ))}
       </div>

--- a/eddist-server/client-v2/package.json
+++ b/eddist-server/client-v2/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@react-router/dev": "^7.13.2",
     "@tailwindcss/vite": "^4.2.2",
+    "@types/dom-chromium-ai": "^0.0.16",
     "@types/encoding-japanese": "^2.2.1",
     "@types/express": "^5.0.6",
     "@types/node": "^22.19.1",

--- a/eddist-server/client-v2/tsconfig.json
+++ b/eddist-server/client-v2/tsconfig.json
@@ -7,7 +7,7 @@
   ],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["node", "vite/client"],
+    "types": ["node", "vite/client", "dom-chromium-ai"],
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@7.3.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.5.0))
+      '@types/dom-chromium-ai':
+        specifier: ^0.0.16
+        version: 0.0.16
       '@types/encoding-japanese':
         specifier: ^2.2.1
         version: 2.2.1
@@ -1155,6 +1158,9 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/dom-chromium-ai@0.0.16':
+    resolution: {integrity: sha512-Z0vOBWckovkc85zctYKGEUUBHaqt9Oz8AUhAVyoNLAsMGlBhMNl/8w1n8JG1y0g7TW03EzWt5RsdcDD70ra58g==}
 
   '@types/encoding-japanese@2.2.1':
     resolution: {integrity: sha512-6jjepuTusvySxMLP7W6usamlbgf0F4sIDvm7EzYePjLHY7zWUv4yz2PLUnu0vuNVtXOTLu2cRdFcDg40J5Owsw==}
@@ -3252,6 +3258,8 @@ snapshots:
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.19.1
+
+  '@types/dom-chromium-ai@0.0.16': {}
 
   '@types/encoding-japanese@2.2.1': {}
 


### PR DESCRIPTION
- Add useSummarizerSupported hook detecting window.ai.summarizer on mount
- Add ThreadSummarizeButton component with wand icon and portal-rendered popover
- Fetch thread .dat, strip HTML from responses, summarize with key-points/plain-text/short options
- Button is conditionally rendered only in browsers that support the API
- Popover auto-positions above or below the button based on viewport space
