### PR TITLE
feat: add CAPTCHA support for thread/response creation

### DIFF
--- a/eddist-admin/client/app/components/CaptchaConfigForm.tsx
+++ b/eddist-admin/client/app/components/CaptchaConfigForm.tsx
@@ -137,10 +137,20 @@ const CaptchaConfigForm = (props: Props) => {
             {...register("endpoint_usage")}
             defaultValue={defaults?.endpoint_usage ?? "auth_code"}
           >
-            <option value="auth_code">auth_code (posting new threads/replies)</option>
+            <option value="auth_code">auth_code (initial posting authentication)</option>
             <option value="re_auth">re_auth (re-authentication)</option>
-            <option value="all">all (both endpoints)</option>
+            <option value="all_auth">all_auth (auth_code + re_auth)</option>
+            <option value="thread_creation">thread_creation (creating new threads)</option>
+            <option value="res_creation">res_creation (posting replies)</option>
+            <option value="all_posting">all_posting (thread_creation + res_creation)</option>
+            <option value="all">all (every endpoint usage above)</option>
           </Select>
+          <p className="text-sm text-gray-500 mt-1">
+            For thread_creation / res_creation / all_posting / all, the client-v2 widget currently
+            only properly supports Cloudflare Turnstile — other providers (e.g. hCaptcha, which
+            reports its token via a hidden &lt;textarea&gt; rather than an &lt;input&gt;) are not
+            yet detected correctly on these posting flows.
+          </p>
         </div>
 
         <div className="grid grid-cols-2 gap-4">

--- a/eddist-server/client-v2/app/api-client/captcha-config.ts
+++ b/eddist-server/client-v2/app/api-client/captcha-config.ts
@@ -1,0 +1,34 @@
+export interface CaptchaWidgetMetadata {
+  form_field_name: string;
+  script_url: string;
+  widget_html: string;
+  script_handler?: string;
+}
+
+export interface CaptchaConfigPublic {
+  provider: string;
+  site_key: string;
+  base_url?: string;
+  widget: CaptchaWidgetMetadata;
+}
+
+export type CaptchaUsage = "thread_creation" | "res_creation";
+
+const _captchaConfigCache = new Map<
+  CaptchaUsage,
+  { data: CaptchaConfigPublic[]; expiresAt: number }
+>();
+
+export const fetchCaptchaConfigs = async (usage: CaptchaUsage): Promise<CaptchaConfigPublic[]> => {
+  const now = Date.now();
+  const cached = _captchaConfigCache.get(usage);
+  if (cached && cached.expiresAt > now) return cached.data;
+
+  const res = await fetch(`/api/captcha-configs?usage=${usage}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch captcha configs for usage "${usage}"`);
+  }
+  const data: CaptchaConfigPublic[] = await res.json();
+  _captchaConfigCache.set(usage, { data, expiresAt: now + 60_000 });
+  return data;
+};

--- a/eddist-server/client-v2/app/components/CaptchaSection.tsx
+++ b/eddist-server/client-v2/app/components/CaptchaSection.tsx
@@ -1,0 +1,30 @@
+import type { useCaptchaPosting } from "../hooks/useCaptchaPosting";
+import CaptchaWidget from "./CaptchaWidget";
+
+interface CaptchaSectionProps {
+  captcha: ReturnType<typeof useCaptchaPosting>;
+}
+
+/** Renders the captcha widgets (and retry error) for a posting flow, shared by PostThreadModal and PostResponseModal. */
+const CaptchaSection = ({ captcha }: CaptchaSectionProps) => {
+  if (captcha.configs.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {captcha.error && (
+        <p className="text-sm text-red-600 dark:text-red-400">
+          認証に失敗しました。もう一度認証を行ってください。
+        </p>
+      )}
+      {captcha.configs.map((config) => (
+        <CaptchaWidget
+          key={`${config.widget.form_field_name}-${captcha.widgetKey}`}
+          config={config}
+          onToken={captcha.onToken}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CaptchaSection;

--- a/eddist-server/client-v2/app/components/CaptchaWidget.tsx
+++ b/eddist-server/client-v2/app/components/CaptchaWidget.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from "react";
+import type { CaptchaConfigPublic } from "../api-client/captcha-config";
+
+interface CaptchaWidgetProps {
+  config: CaptchaConfigPublic;
+  onToken: (fieldName: string, token: string) => void;
+}
+
+const resolvePlaceholders = (template: string, siteKey: string, baseUrl?: string): string =>
+  template.replace(/\{\{site_key\}\}/g, siteKey).replace(/\{\{base_url\}\}/g, baseUrl ?? "");
+
+const loadScript = (src: string): void => {
+  if (document.head.querySelector(`script[src="${CSS.escape(src)}"]`)) return;
+  const script = document.createElement("script");
+  script.src = src;
+  script.async = true;
+  document.head.appendChild(script);
+};
+
+/**
+ * Renders a third-party captcha widget (Turnstile/hCaptcha/Cap/etc.) from
+ * server-provided metadata, and reports the token once the widget populates
+ * its hidden `<input name={form_field_name}>`.
+ */
+const CaptchaWidget = ({ config, onToken }: CaptchaWidgetProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onTokenRef = useRef(onToken);
+  onTokenRef.current = onToken;
+
+  const scriptUrl = resolvePlaceholders(config.widget.script_url, config.site_key, config.base_url);
+  const widgetHtml = resolvePlaceholders(
+    config.widget.widget_html,
+    config.site_key,
+    config.base_url,
+  );
+  const scriptHandler = config.widget.script_handler
+    ? resolvePlaceholders(config.widget.script_handler, config.site_key, config.base_url)
+    : undefined;
+
+  useEffect(() => {
+    if (scriptUrl) loadScript(scriptUrl);
+  }, [scriptUrl]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let handlerScript: HTMLScriptElement | undefined;
+    if (scriptHandler) {
+      handlerScript = document.createElement("script");
+      handlerScript.textContent = scriptHandler;
+      container.appendChild(handlerScript);
+    }
+
+    const fieldName = config.widget.form_field_name;
+    let reported = false;
+    const reportIfPresent = () => {
+      if (reported) return;
+      const input = container.querySelector<HTMLInputElement>(
+        `input[name="${CSS.escape(fieldName)}"]`,
+      );
+      if (input?.value) {
+        reported = true;
+        onTokenRef.current(fieldName, input.value);
+      }
+    };
+
+    reportIfPresent();
+    const observer = new MutationObserver(reportIfPresent);
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["value"],
+    });
+
+    return () => {
+      observer.disconnect();
+      handlerScript?.remove();
+    };
+  }, [config.widget.form_field_name, scriptHandler]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="captcha-widget"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: widget HTML comes from server-side captcha provider config, not user input
+      dangerouslySetInnerHTML={{ __html: widgetHtml }}
+    />
+  );
+};
+
+export default CaptchaWidget;

--- a/eddist-server/client-v2/app/components/PostResponseModal.tsx
+++ b/eddist-server/client-v2/app/components/PostResponseModal.tsx
@@ -1,7 +1,9 @@
 import { Button, Label, Modal, ModalBody, ModalHeader, Textarea, TextInput } from "flowbite-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { useCaptchaPosting } from "../hooks/useCaptchaPosting";
 import AuthCodeModal from "./AuthCodeModal";
+import CaptchaSection from "./CaptchaSection";
 import ErrorModal from "./ErrorModal";
 import { postResponse } from "./utils";
 
@@ -21,6 +23,8 @@ const PostResponseModal = (props: PostResponseModalProps) => {
   const [authCode, setAuthCode] = useState("");
   const [errorModal, serErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+
+  const captcha = useCaptchaPosting("res_creation", props.open);
 
   return (
     <Modal
@@ -52,6 +56,7 @@ const PostResponseModal = (props: PostResponseModalProps) => {
               body: data.body,
               boardKey: props.boardKey,
               threadKey: props.threadKey,
+              captchaTokens: captcha.tokens,
             });
 
             if (!result.success) {
@@ -59,6 +64,9 @@ const PostResponseModal = (props: PostResponseModalProps) => {
                 case "auth-code":
                   setAuthCode(result.error.authCode);
                   setOpenAuthCodeModal(true);
+                  return;
+                case "captcha":
+                  captcha.onFailure();
                   return;
                 case "unknown":
                   serErrorModal(true);
@@ -101,8 +109,12 @@ const PostResponseModal = (props: PostResponseModalProps) => {
               />
             </div>
 
+            <CaptchaSection captcha={captcha} />
+
             <div className="w-full">
-              <Button type="submit">書き込む</Button>
+              <Button type="submit" disabled={captcha.isPending}>
+                書き込む
+              </Button>
             </div>
           </div>
         </form>

--- a/eddist-server/client-v2/app/components/PostThreadModal.tsx
+++ b/eddist-server/client-v2/app/components/PostThreadModal.tsx
@@ -1,7 +1,9 @@
 import { Button, Label, Modal, ModalBody, ModalHeader, Textarea, TextInput } from "flowbite-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { useCaptchaPosting } from "../hooks/useCaptchaPosting";
 import AuthCodeModal from "./AuthCodeModal";
+import CaptchaSection from "./CaptchaSection";
 import ErrorModal from "./ErrorModal";
 import { postThread } from "./utils";
 
@@ -19,6 +21,8 @@ const PostThreadModal = (props: PostThreadModalProps) => {
   const [errorMessage, setErrorMessage] = useState("");
 
   const { register, handleSubmit } = useForm();
+
+  const captcha = useCaptchaPosting("thread_creation", props.open);
 
   return (
     <Modal show={props.open} size="5xl" onClose={() => props.setOpen(false)} dismissible>
@@ -44,12 +48,16 @@ const PostThreadModal = (props: PostThreadModalProps) => {
               mail: data.mail,
               body: data.body,
               boardKey: props.boardKey,
+              captchaTokens: captcha.tokens,
             });
             if (!result.success) {
               switch (result.error.kind) {
                 case "auth-code":
                   setAuthCode(result.error.authCode);
                   setOpenAuthCodeModal(true);
+                  return;
+                case "captcha":
+                  captcha.onFailure();
                   return;
                 case "unknown":
                   serErrorModal(true);
@@ -101,8 +109,12 @@ const PostThreadModal = (props: PostThreadModalProps) => {
               />
             </div>
 
+            <CaptchaSection captcha={captcha} />
+
             <div className="w-full">
-              <Button type="submit">書き込む</Button>
+              <Button type="submit" disabled={captcha.isPending}>
+                書き込む
+              </Button>
             </div>
           </div>
         </form>

--- a/eddist-server/client-v2/app/components/utils.ts
+++ b/eddist-server/client-v2/app/components/utils.ts
@@ -6,6 +6,7 @@ interface ResponseInput {
   body: string;
   boardKey: string;
   threadKey: string;
+  captchaTokens?: Record<string, string>;
 }
 
 interface ThreadCreateInput {
@@ -14,6 +15,7 @@ interface ThreadCreateInput {
   mail: string;
   body: string;
   boardKey: string;
+  captchaTokens?: Record<string, string>;
 }
 
 type PostResponseResult = PostResponseSuccess | PostResponseFailure;
@@ -24,7 +26,7 @@ interface PostResponseSuccess {
 
 interface PostResponseFailure {
   success: false;
-  error: PostResponseFailureAuthCode | PostResponseFailureUnknown;
+  error: PostResponseFailureAuthCode | PostResponseFailureCaptcha | PostResponseFailureUnknown;
 }
 
 interface PostResponseFailureAuthCode {
@@ -32,10 +34,19 @@ interface PostResponseFailureAuthCode {
   authCode: string;
 }
 
+interface PostResponseFailureCaptcha {
+  kind: "captcha";
+}
+
 interface PostResponseFailureUnknown {
   kind: "unknown";
   errorHtml: string;
 }
+
+const captchaTokensToQueryString = (captchaTokens?: Record<string, string>): string =>
+  Object.entries(captchaTokens ?? {})
+    .map(([field, token]) => `&${encodeURIComponent(field)}=${encodeURIComponent(token)}`)
+    .join("");
 
 const convertToSjisText = (text: string): string => {
   const resultArray = [];
@@ -97,6 +108,7 @@ export const postResponse = async ({
   body,
   boardKey,
   threadKey,
+  captchaTokens,
 }: ResponseInput): Promise<PostResponseResult> => {
   const params = {
     submit: convertToSjisText("書き込む"),
@@ -124,7 +136,9 @@ export const postResponse = async ({
       "&bbs=" +
       params.bbs +
       "&key=" +
-      params.key,
+      params.key +
+      "&is_browser=1" +
+      captchaTokensToQueryString(captchaTokens),
   });
 
   return await afterPost(res);
@@ -136,6 +150,7 @@ export const postThread = async ({
   mail,
   body,
   boardKey,
+  captchaTokens,
 }: ThreadCreateInput): Promise<PostResponseResult> => {
   const params = {
     submit: convertToSjisText("新規スレッド作成"),
@@ -163,7 +178,9 @@ export const postThread = async ({
       "&bbs=" +
       params.bbs +
       "&subject=" +
-      params.subject,
+      params.subject +
+      "&is_browser=1" +
+      captchaTokensToQueryString(captchaTokens),
   });
 
   return await afterPost(res);
@@ -197,6 +214,8 @@ const afterPost = async (res: Response): Promise<PostResponseResult> => {
     if (text.includes("E-Unauthenticated")) {
       const authCode = extractAuthCodeWhenUnauthenticated(text);
       return { success: false, error: { kind: "auth-code", authCode } };
+    } else if (text.includes("E-CaptchaError")) {
+      return { success: false, error: { kind: "captcha" } };
     } else {
       const doc = new DOMParser().parseFromString(text, "text/html");
       return {

--- a/eddist-server/client-v2/app/hooks/useCaptchaPosting.ts
+++ b/eddist-server/client-v2/app/hooks/useCaptchaPosting.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import {
+  type CaptchaConfigPublic,
+  type CaptchaUsage,
+  fetchCaptchaConfigs,
+} from "../api-client/captcha-config";
+
+/**
+ * Loads the captcha widgets required for a posting flow (thread/response
+ * creation) and tracks the tokens collected from them, including the
+ * retry-on-failure cycle shared by PostThreadModal and PostResponseModal.
+ */
+export const useCaptchaPosting = (usage: CaptchaUsage, open: boolean) => {
+  const [configs, setConfigs] = useState<CaptchaConfigPublic[]>([]);
+  const [tokens, setTokens] = useState<Record<string, string>>({});
+  const [error, setError] = useState(false);
+  const [widgetKey, setWidgetKey] = useState(0);
+
+  useEffect(() => {
+    if (!open) return;
+    setTokens({});
+    setError(false);
+    fetchCaptchaConfigs(usage)
+      .then(setConfigs)
+      .catch(() => setConfigs([]));
+  }, [open, usage]);
+
+  const isPending = configs.some((c) => !tokens[c.widget.form_field_name]);
+
+  const onToken = (fieldName: string, token: string) => {
+    setError(false);
+    setTokens((prev) => ({ ...prev, [fieldName]: token }));
+  };
+
+  const onFailure = () => {
+    setError(true);
+    setTokens({});
+    setWidgetKey((k) => k + 1);
+  };
+
+  return { configs, tokens, error, widgetKey, isPending, onToken, onFailure };
+};

--- a/eddist-server/src/app.rs
+++ b/eddist-server/src/app.rs
@@ -32,6 +32,7 @@ use crate::{
     routes::{
         auth_code::{get_auth_code, post_auth_code},
         bbs_cgi::post_bbs_cgi,
+        captcha_config_api::get_api_captcha_configs,
         dat_routing::{get_dat_txt, get_kako_dat_txt},
         notice::{get_latest_notices, get_notice_by_slug, get_notices_paginated},
         re_auth::{get_re_auth, post_re_auth},
@@ -259,6 +260,7 @@ pub fn create_app(app_state: AppState, conn_mgr: redis::aio::ConnectionManager) 
         .route("/api/notices", get(get_notices_paginated))
         .route("/api/notices/{slug}", get(get_notice_by_slug))
         .route("/api/client-config", get(get_api_client_config))
+        .route("/api/captcha-configs", get(get_api_captcha_configs))
         .route("/api/stats", get(get_stats))
         .route(
             "/api/{boardKey}/unsafe-thread-ids",

--- a/eddist-server/src/domain/captcha_like.rs
+++ b/eddist-server/src/domain/captcha_like.rs
@@ -110,6 +110,10 @@ pub enum CaptchaEndpointUsage {
     #[default]
     AuthCode,
     ReAuth,
+    AllAuth,
+    ThreadCreation,
+    ResponseCreation,
+    AllPosting,
     All,
 }
 
@@ -117,17 +121,116 @@ impl CaptchaEndpointUsage {
     pub fn from_str(s: &str) -> Self {
         match s {
             "re_auth" => Self::ReAuth,
+            "all_auth" => Self::AllAuth,
+            "thread_creation" => Self::ThreadCreation,
+            "res_creation" => Self::ResponseCreation,
+            "all_posting" => Self::AllPosting,
             "all" => Self::All,
             _ => Self::AuthCode,
         }
     }
 
     pub fn matches_auth_code(&self) -> bool {
-        matches!(self, Self::AuthCode | Self::All)
+        matches!(self, Self::AuthCode | Self::AllAuth | Self::All)
     }
 
     pub fn matches_reauth(&self) -> bool {
-        matches!(self, Self::ReAuth | Self::All)
+        matches!(self, Self::ReAuth | Self::AllAuth | Self::All)
+    }
+
+    pub fn matches_thread_creation(&self) -> bool {
+        matches!(self, Self::ThreadCreation | Self::AllPosting | Self::All)
+    }
+
+    pub fn matches_response_creation(&self) -> bool {
+        matches!(self, Self::ResponseCreation | Self::AllPosting | Self::All)
+    }
+}
+
+#[cfg(test)]
+mod captcha_endpoint_usage_tests {
+    use super::*;
+
+    #[test]
+    fn from_str_maps_wire_strings_to_variants() {
+        assert_eq!(
+            CaptchaEndpointUsage::from_str("auth_code"),
+            CaptchaEndpointUsage::AuthCode
+        );
+        assert_eq!(
+            CaptchaEndpointUsage::from_str("re_auth"),
+            CaptchaEndpointUsage::ReAuth
+        );
+        assert_eq!(
+            CaptchaEndpointUsage::from_str("all_auth"),
+            CaptchaEndpointUsage::AllAuth
+        );
+        assert_eq!(
+            CaptchaEndpointUsage::from_str("thread_creation"),
+            CaptchaEndpointUsage::ThreadCreation
+        );
+        assert_eq!(
+            CaptchaEndpointUsage::from_str("res_creation"),
+            CaptchaEndpointUsage::ResponseCreation
+        );
+        assert_eq!(
+            CaptchaEndpointUsage::from_str("all_posting"),
+            CaptchaEndpointUsage::AllPosting
+        );
+        assert_eq!(
+            CaptchaEndpointUsage::from_str("all"),
+            CaptchaEndpointUsage::All
+        );
+        // Unknown values fall back to the default (AuthCode)
+        assert_eq!(
+            CaptchaEndpointUsage::from_str("garbage"),
+            CaptchaEndpointUsage::AuthCode
+        );
+    }
+
+    #[test]
+    fn individual_variants_match_only_their_own_endpoint() {
+        assert!(CaptchaEndpointUsage::AuthCode.matches_auth_code());
+        assert!(!CaptchaEndpointUsage::AuthCode.matches_reauth());
+        assert!(!CaptchaEndpointUsage::AuthCode.matches_thread_creation());
+        assert!(!CaptchaEndpointUsage::AuthCode.matches_response_creation());
+
+        assert!(CaptchaEndpointUsage::ReAuth.matches_reauth());
+        assert!(!CaptchaEndpointUsage::ReAuth.matches_auth_code());
+
+        assert!(CaptchaEndpointUsage::ThreadCreation.matches_thread_creation());
+        assert!(!CaptchaEndpointUsage::ThreadCreation.matches_response_creation());
+        assert!(!CaptchaEndpointUsage::ThreadCreation.matches_auth_code());
+        assert!(!CaptchaEndpointUsage::ThreadCreation.matches_reauth());
+
+        assert!(CaptchaEndpointUsage::ResponseCreation.matches_response_creation());
+        assert!(!CaptchaEndpointUsage::ResponseCreation.matches_thread_creation());
+        assert!(!CaptchaEndpointUsage::ResponseCreation.matches_auth_code());
+        assert!(!CaptchaEndpointUsage::ResponseCreation.matches_reauth());
+    }
+
+    #[test]
+    fn all_auth_groups_only_auth_related_endpoints() {
+        assert!(CaptchaEndpointUsage::AllAuth.matches_auth_code());
+        assert!(CaptchaEndpointUsage::AllAuth.matches_reauth());
+        assert!(!CaptchaEndpointUsage::AllAuth.matches_thread_creation());
+        assert!(!CaptchaEndpointUsage::AllAuth.matches_response_creation());
+    }
+
+    #[test]
+    fn all_posting_groups_only_posting_related_endpoints() {
+        assert!(CaptchaEndpointUsage::AllPosting.matches_thread_creation());
+        assert!(CaptchaEndpointUsage::AllPosting.matches_response_creation());
+        assert!(!CaptchaEndpointUsage::AllPosting.matches_auth_code());
+        assert!(!CaptchaEndpointUsage::AllPosting.matches_reauth());
+    }
+
+    #[test]
+    fn all_matches_every_endpoint_usage() {
+        assert!(CaptchaEndpointUsage::All.matches_auth_code());
+        assert!(CaptchaEndpointUsage::All.matches_reauth());
+        assert!(CaptchaEndpointUsage::All.matches_thread_creation());
+        assert!(CaptchaEndpointUsage::All.matches_response_creation());
     }
 }
 

--- a/eddist-server/src/error.rs
+++ b/eddist-server/src/error.rs
@@ -104,6 +104,9 @@ pub enum BbsCgiError {
     ReAuthRequired { temp_key: String, base_url: String },
 
     #[error(transparent)]
+    CaptchaError(#[from] CaptchaLikeError),
+
+    #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
 
@@ -135,6 +138,7 @@ impl BbsCgiError {
             BbsCgiError::EmailAuthenticatedUnsupportedUserAgent => StatusCode::OK,
             BbsCgiError::TemporarilySuspended => StatusCode::FORBIDDEN,
             BbsCgiError::ReAuthRequired { .. } => StatusCode::FORBIDDEN,
+            BbsCgiError::CaptchaError(_) => StatusCode::OK,
             BbsCgiError::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -168,6 +172,7 @@ impl BbsCgiError {
             }
             BbsCgiError::TemporarilySuspended => "TemporarilySuspended",
             BbsCgiError::ReAuthRequired { .. } => "ReAuthRequired",
+            BbsCgiError::CaptchaError(_) => "CaptchaError",
             BbsCgiError::Other(_) => "InternalError",
         }
     }

--- a/eddist-server/src/lib.rs
+++ b/eddist-server/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) mod utils;
 mod routes {
     pub mod auth_code;
     pub mod bbs_cgi;
+    pub mod captcha_config_api;
     pub mod dat_routing;
     pub mod notice;
     pub mod re_auth;

--- a/eddist-server/src/routes/bbs_cgi.rs
+++ b/eddist-server/src/routes/bbs_cgi.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use axum::{
     body::Body,
     extract::State,
@@ -10,10 +12,15 @@ use jsonwebtoken::EncodingKey;
 
 use crate::{
     AppState,
+    domain::captcha_like::CaptchaProviderConfig,
     error::{BbsCgiError, InsufficientParamType, InvalidParamType},
     services::{
         AppService, BbsCgiService,
         bind_token_to_user_service::BindTokenToUserServiceInput,
+        captcha_config_cache::{
+            get_cached_captcha_configs_for_response_creation,
+            get_cached_captcha_configs_for_thread_creation,
+        },
         res_creation_service::{ResCreationServiceInput, ResCreationServiceOutput},
         server_settings_cache::{ServerSettingKey, get_server_setting_bool},
         stats_counter::{increment_board_response_delta, increment_board_thread_delta},
@@ -101,6 +108,27 @@ pub async fn post_bbs_cgi(
     let require_user_registration =
         get_server_setting_bool(ServerSettingKey::RequireIdpLinking).await;
 
+    // Dedicated 2ch-compatible client apps (専ブラ) cannot render a captcha widget,
+    // so only require captcha verification for clients that explicitly identify as
+    // browser-capable (the official client-v2 web app sends `is_browser=1`).
+    let is_browser = form.get("is_browser").is_some_and(|v| v == "1");
+    let captcha_configs: Vec<CaptchaProviderConfig> = if is_browser {
+        if is_thread {
+            get_cached_captcha_configs_for_thread_creation().await
+        } else {
+            get_cached_captcha_configs_for_response_creation().await
+        }
+    } else {
+        Vec::new()
+    };
+    let captcha_responses: HashMap<String, String> = captcha_configs
+        .iter()
+        .filter_map(|c| {
+            form.get(c.widget.form_field_name.as_str())
+                .map(|v| (c.widget.form_field_name.clone(), v.to_string()))
+        })
+        .collect();
+
     let (tinker, res_order, authed_token_id, is_authed_token_bound) = if is_thread {
         let Some(title) = form.get("subject").map(|x| x.to_string()) else {
             return BbsCgiError::from(InsufficientParamType::Subject).into_response();
@@ -120,6 +148,8 @@ pub async fn post_bbs_cgi(
                 user_agent: ua.to_string(),
                 asn_num,
                 require_user_registration,
+                captcha_like_configs: captcha_configs,
+                captcha_responses,
             })
             .await
         {
@@ -158,6 +188,8 @@ pub async fn post_bbs_cgi(
                 user_agent: ua.to_string(),
                 asn_num,
                 require_user_registration,
+                captcha_like_configs: captcha_configs,
+                captcha_responses,
             })
             .await
         {

--- a/eddist-server/src/routes/captcha_config_api.rs
+++ b/eddist-server/src/routes/captcha_config_api.rs
@@ -1,0 +1,61 @@
+use axum::{
+    Json,
+    extract::Query,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    domain::captcha_like::{CaptchaProviderConfig, CaptchaWidgetMetadata},
+    services::captcha_config_cache::{
+        get_cached_captcha_configs_for_response_creation,
+        get_cached_captcha_configs_for_thread_creation,
+    },
+};
+
+#[derive(Debug, Deserialize)]
+pub struct CaptchaUsageQuery {
+    pub usage: String,
+}
+
+/// Public, secret-free view of a captcha provider config — only what the
+/// frontend needs to render a widget and submit its token.
+#[derive(Debug, Serialize)]
+pub struct CaptchaConfigPublic {
+    pub provider: String,
+    pub site_key: String,
+    pub base_url: Option<String>,
+    pub widget: CaptchaWidgetMetadata,
+}
+
+impl From<&CaptchaProviderConfig> for CaptchaConfigPublic {
+    fn from(config: &CaptchaProviderConfig) -> Self {
+        Self {
+            provider: config.provider.clone(),
+            site_key: config.site_key.clone(),
+            base_url: config.base_url.clone(),
+            widget: config.widget.clone(),
+        }
+    }
+}
+
+/// Returns the active captcha widget configs (without secrets) for a posting
+/// flow, so the client knows which widgets to render before submitting.
+///
+/// `usage` must be `thread_creation` or `res_creation` — the same wire
+/// vocabulary as `CaptchaEndpointUsage`. Other usages (auth_code/re_auth/...)
+/// have their own server-rendered or cross-cutting flows and are intentionally
+/// not exposed here.
+pub async fn get_api_captcha_configs(Query(params): Query<CaptchaUsageQuery>) -> Response {
+    let configs = match params.usage.as_str() {
+        "thread_creation" => get_cached_captcha_configs_for_thread_creation().await,
+        "res_creation" => get_cached_captcha_configs_for_response_creation().await,
+        _ => {
+            return (StatusCode::BAD_REQUEST, "invalid usage").into_response();
+        }
+    };
+
+    let configs: Vec<CaptchaConfigPublic> = configs.iter().map(CaptchaConfigPublic::from).collect();
+    Json(configs).into_response()
+}

--- a/eddist-server/src/services.rs
+++ b/eddist-server/src/services.rs
@@ -45,6 +45,7 @@ pub(crate) mod kako_thread_retrieval_service;
 pub(crate) mod list_boards_service;
 pub(crate) mod metadent_thread_list_service;
 pub(crate) mod openai_moderation_service;
+pub(crate) mod post_captcha_verification;
 pub(crate) mod reauth_service;
 pub(crate) mod res_creation_service;
 pub mod server_settings_cache;

--- a/eddist-server/src/services/captcha_config_cache.rs
+++ b/eddist-server/src/services/captcha_config_cache.rs
@@ -57,6 +57,28 @@ pub async fn get_cached_captcha_configs_for_reauth() -> Vec<CaptchaProviderConfi
         .collect()
 }
 
+/// Get cached captcha configs required when creating a new thread
+pub async fn get_cached_captcha_configs_for_thread_creation() -> Vec<CaptchaProviderConfig> {
+    let cache = get_global_cache().read().await;
+    cache
+        .configs
+        .iter()
+        .filter(|c| c.endpoint_usage.matches_thread_creation())
+        .cloned()
+        .collect()
+}
+
+/// Get cached captcha configs required when posting a reply
+pub async fn get_cached_captcha_configs_for_response_creation() -> Vec<CaptchaProviderConfig> {
+    let cache = get_global_cache().read().await;
+    cache
+        .configs
+        .iter()
+        .filter(|c| c.endpoint_usage.matches_response_creation())
+        .cloned()
+        .collect()
+}
+
 /// Refresh the cache with new configs from the database
 pub async fn refresh_captcha_config_cache(
     repo: &dyn CaptchaConfigRepository,

--- a/eddist-server/src/services/post_captcha_verification.rs
+++ b/eddist-server/src/services/post_captcha_verification.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+
+use futures::future::join_all;
+use redis::aio::ConnectionManager;
+
+use crate::{
+    domain::captcha_like::CaptchaProviderConfig,
+    external::captcha_like_client::{
+        CaptchaLikeError, CaptchaLikeResult, CaptchaVerificationOutput, create_captcha_client,
+    },
+};
+
+/// Verify captcha responses for a posting flow (thread/response creation).
+///
+/// Unlike `auth_with_code_service`'s verification, there is no authed token to
+/// fall back on for IP equality checks (e.g. Monocle-style providers), so every
+/// `Failure` variant — including `FailedToVerifyIpAddress` — is treated as a
+/// hard failure here.
+pub async fn verify_post_captchas(
+    configs: &[CaptchaProviderConfig],
+    responses: &HashMap<String, String>,
+    origin_ip: &str,
+    redis_conn: ConnectionManager,
+) -> Result<(), CaptchaLikeError> {
+    let mut clients = Vec::with_capacity(configs.len());
+    for config in configs {
+        let form_field_name = config.widget.form_field_name.as_str();
+        if !responses.contains_key(form_field_name) {
+            tracing::error!(
+                provider = %config.provider,
+                field = %form_field_name,
+                "captcha response not found in form"
+            );
+            return Err(CaptchaLikeError::FailedToVerifyCaptcha);
+        }
+        clients.push(create_captcha_client(config, redis_conn.clone()));
+    }
+
+    let verifications = configs.iter().zip(clients.iter()).map(|(config, client)| {
+        let response = &responses[config.widget.form_field_name.as_str()];
+        client.verify_captcha(response, origin_ip)
+    });
+    let results = join_all(verifications).await;
+
+    for (config, result) in configs.iter().zip(results) {
+        match result {
+            Ok(CaptchaVerificationOutput {
+                result: CaptchaLikeResult::Success,
+                captured_data,
+                provider,
+            }) => {
+                if let Some(data) = captured_data {
+                    tracing::debug!(provider = %provider, captured_data = ?data, "captcha verification succeeded");
+                }
+            }
+            Ok(CaptchaVerificationOutput {
+                result: CaptchaLikeResult::Failure(e),
+                captured_data,
+                provider,
+            }) => {
+                if let Some(data) = captured_data {
+                    tracing::debug!(provider = %provider, captured_data = ?data, "captcha verification failed");
+                }
+                tracing::warn!(provider = %provider, error = %e, "captcha verification failed");
+                return Err(e);
+            }
+            Err(e) => {
+                tracing::error!(provider = %config.provider, error = %e, "captcha verification request failed");
+                return Err(CaptchaLikeError::FailedToVerifyCaptcha);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/eddist-server/src/services/res_creation_service.rs
+++ b/eddist-server/src/services/res_creation_service.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashMap};
 
 use anyhow::anyhow;
 use chrono::Utc;
@@ -18,6 +18,7 @@ use uuid::Uuid;
 
 use crate::{
     domain::{
+        captcha_like::CaptchaProviderConfig,
         ng_word::NgWordRestrictable,
         res::Res,
         res_core::ResCore,
@@ -43,6 +44,7 @@ use eddist_core::redis_keys::thread_cache_key;
 
 use super::{
     BbsCgiService, openai_moderation_service,
+    post_captcha_verification::verify_post_captchas,
     server_settings_cache::{ServerSettingKey, get_server_setting_bool},
     validation::{check_userreg, resolve_cap_name},
 };
@@ -155,6 +157,17 @@ impl<
                 input.require_user_registration,
             )
             .await?;
+
+        if !input.captcha_like_configs.is_empty() {
+            verify_post_captchas(
+                &input.captcha_like_configs,
+                &input.captcha_responses,
+                &input.ip_addr,
+                redis_conn.clone(),
+            )
+            .await
+            .map_err(BbsCgiError::CaptchaError)?;
+        }
 
         let email_auth_service = EmailAuthRestrictionService::new(redis_conn.clone());
         email_auth_service
@@ -358,6 +371,8 @@ pub struct ResCreationServiceInput {
     pub user_agent: String,
     pub asn_num: u32,
     pub require_user_registration: bool,
+    pub captcha_like_configs: Vec<CaptchaProviderConfig>,
+    pub captcha_responses: HashMap<String, String>,
 }
 
 pub struct ResCreationServiceOutput {

--- a/eddist-server/src/services/thread_creation_service.rs
+++ b/eddist-server/src/services/thread_creation_service.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashMap};
 
 use chrono::Utc;
 use eddist_core::{
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 use crate::{
     domain::{
+        captcha_like::CaptchaProviderConfig,
         ng_word::NgWordRestrictable,
         res::Res,
         res_core::ResCore,
@@ -36,6 +37,7 @@ use eddist_core::redis_keys::thread_cache_key;
 
 use super::{
     BbsCgiService, openai_moderation_service,
+    post_captcha_verification::verify_post_captchas,
     server_settings_cache::{ServerSettingKey, get_server_setting_bool},
     validation::{check_userreg, resolve_cap_name},
 };
@@ -136,6 +138,17 @@ impl<T: BbsRepository + Clone, U: UserRepository + Clone, E: CreationEventReposi
                 input.require_user_registration,
             )
             .await?;
+
+        if !input.captcha_like_configs.is_empty() {
+            verify_post_captchas(
+                &input.captcha_like_configs,
+                &input.captcha_responses,
+                &input.ip_addr,
+                redis_conn.clone(),
+            )
+            .await
+            .map_err(BbsCgiError::CaptchaError)?;
+        }
 
         let email_auth_service = EmailAuthRestrictionService::new(self.2.clone());
         email_auth_service
@@ -297,6 +310,8 @@ pub struct ThreadCreationServiceInput {
     pub user_agent: String,
     pub asn_num: u32,
     pub require_user_registration: bool,
+    pub captcha_like_configs: Vec<CaptchaProviderConfig>,
+    pub captcha_responses: HashMap<String, String>,
 }
 
 pub struct ThreadCreationServiceOutput {


### PR DESCRIPTION
Implements full-stack CAPTCHA gating for posting flows (thread creation and response/reply creation) as independently-configurable endpoint usages, extending the existing CAPTCHA subsystem to cover new flows beyond auth.

Backend changes:
- Extend CaptchaEndpointUsage enum with AllAuth, ThreadCreation, ResponseCreation, AllPosting variants following repo's orthogonal per-endpoint convention (matches AiModerationOnThread/Res pattern)
- Add cache accessors for thread/response creation mirroring auth pair
- New verify_post_captchas helper for auth-agnostic verification
- Wire verification into ThreadCreationService/ResCreationService right after auth-token validation
- New BbsCgiError::CaptchaError variant for error tagging
- Wire is_browser=1 form field gate in bbs_cgi route for legacy 2ch-client compatibility (ChMate, JaneStyle don't support widgets)
- New /api/captcha-configs?usage=thread_creation|res_creation JSON endpoint exposing secret-free widget metadata

Frontend changes:
- New CaptchaWidget React component: resolves placeholders, loads scripts, watches for tokens via MutationObserver
- Wire widgets into PostThreadModal/PostResponseModal: fetch on open, gate submit until all tokens present, handle captcha failures by remounting widget
- utils.ts: always send is_browser=1, append captchaTokens to POST body, detect E-CaptchaError as new failure kind

Admin changes:
- Update CaptchaConfigForm dropdown with new variants and corrected labels (fix: auth_code was labeled as posting, clarify all's scope)

Wire strings (VARCHAR(16) constraint):
- 'res_creation' not 'response_creation' (12 chars vs 17), following repo convention of Res/res abbreviation

Verification:
- All 30 Rust tests pass (5 new for CaptchaEndpointUsage grouping algebra)
- No new clippy warnings
- Frontend typecheck/lint clean (biome)
- Manual e2e with docker-dev + captcha-config.json test keys pending