### PR TITLE
ci: pin pnpm to 10.12.1 instead of "latest"

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -37,7 +37,7 @@ jobs:
         name: Install pnpm
         with:
           run_install: false
-          version: "latest"
+          version: "10.12.1"
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -31,7 +31,7 @@ jobs:
         name: Install pnpm
         with:
           run_install: false
-          version: "latest"
+          version: "10.12.1"
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           run_install: false
-          version: "latest"
+          version: "10.12.1"
 
       - name: Setup Node.js & cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Install pnpm
         with:
           run_install: false
-          version: "latest"
+          version: "10.12.1"
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Problem

CI (`build-client`) started failing on 2026-07-12 across all branches — including previously-green ones — at the **Install pnpm** step:

```
Running self-installer...
##[error]Something went wrong, self-installer exits with code 1
```

Root cause is external, not our code: all workflows use `pnpm/action-setup` with `version: "latest"`. pnpm published a new latest release whose self-installer fails on the GitHub Actions runners (Ubuntu 22.04 / Node 22). The same branch passed on 2026-06-16 with no workflow changes since — only pnpm's `latest` moved.

## Fix

Pin pnpm to **10.12.1** (matches local dev; compatible with `lockfileVersion: 9.0`) in every workflow that installs pnpm, so builds are reproducible and no longer break when pnpm ships a new release:

- `.github/workflows/ci-check.yml`
- `.github/workflows/ci-main.yml`
- `.github/workflows/release.yml`
- `.github/workflows/release-beta.yaml`

Merging this to `main` unblocks CI on all open PRs (including the fail-closed header PR `fix/high-medium-severity-bugs`).