### PR TITLE
feat: shared NG ID feature preparation

### DIFF
--- a/eddist-core/src/redis_keys.rs
+++ b/eddist-core/src/redis_keys.rs
@@ -78,6 +78,14 @@ pub fn not_found_access_count_key(ip: &str) -> String {
     format!("not_found:count:{ip}")
 }
 
+pub fn shared_ng_id_key(board_key: &str, ng_id: &str) -> String {
+    format!("shared_ng_id:{board_key}:{ng_id}")
+}
+
+pub fn shared_ng_id_rate_limit_key(token_hash: &str) -> String {
+    format!("shared_ng_id:rate_limit:{token_hash}")
+}
+
 pub const DB_FAILED_CACHE_RES_KEY: &str = "bbs:db_failed_cache:res";
 
 pub const CHANNEL_RES_CREATED: &str = "bbs:event:res_created";

--- a/eddist-core/src/redis_keys.rs
+++ b/eddist-core/src/redis_keys.rs
@@ -86,6 +86,10 @@ pub fn shared_ng_id_rate_limit_key(token_hash: &str) -> String {
     format!("shared_ng_id:rate_limit:{token_hash}")
 }
 
+pub fn shared_ng_id_ip_rate_limit_key(reduced_ip: &str) -> String {
+    format!("shared_ng_id:ip_rate_limit:{reduced_ip}")
+}
+
 pub const DB_FAILED_CACHE_RES_KEY: &str = "bbs:db_failed_cache:res";
 
 pub const CHANNEL_RES_CREATED: &str = "bbs:event:res_created";
@@ -94,3 +98,24 @@ pub use crate::domain::pubsub_repository::{
     CHANNEL_AUTH_TOKEN_INITIATED, CHANNEL_AUTH_TOKEN_REQUESTED, CHANNEL_AUTH_TOKEN_REVOKED,
     CHANNEL_AUTH_TOKEN_SUCCEEDED, CHANNEL_PUBSUB_ITEM,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_shared_ng_id_ip_rate_limit_key_v4() {
+        assert_eq!(
+            shared_ng_id_ip_rate_limit_key("203.0.113.1"),
+            "shared_ng_id:ip_rate_limit:203.0.113.1"
+        );
+    }
+
+    #[test]
+    fn test_shared_ng_id_ip_rate_limit_key_reduced_v6() {
+        assert_eq!(
+            shared_ng_id_ip_rate_limit_key("2001:db8:85a3:0"),
+            "shared_ng_id:ip_rate_limit:2001:db8:85a3:0"
+        );
+    }
+}

--- a/eddist-server/client-v2/app/api-client/ng_id.ts
+++ b/eddist-server/client-v2/app/api-client/ng_id.ts
@@ -1,0 +1,24 @@
+// Shared NG ID sync. Client-only, best-effort: the same-origin fetch attaches the
+// edge-token cookie automatically, and failures must not block the local NG experience.
+
+export const addSharedNgId = async (boardKey: string, ngId: string): Promise<void> => {
+  try {
+    await fetch(`/api/${boardKey}/ng-ids`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ng_id: ngId }),
+    });
+  } catch (e) {
+    console.error("[sharedNgId] add failed", e);
+  }
+};
+
+export const deleteSharedNgId = async (boardKey: string, ngId: string): Promise<void> => {
+  try {
+    await fetch(`/api/${boardKey}/ng-ids/${encodeURIComponent(ngId)}`, {
+      method: "DELETE",
+    });
+  } catch (e) {
+    console.error("[sharedNgId] delete failed", e);
+  }
+};

--- a/eddist-server/client-v2/app/api-client/ng_id.ts
+++ b/eddist-server/client-v2/app/api-client/ng_id.ts
@@ -1,6 +1,3 @@
-// Shared NG ID sync. Client-only, best-effort: the same-origin fetch attaches the
-// edge-token cookie automatically, and failures must not block the local NG experience.
-
 export const addSharedNgId = async (boardKey: string, ngId: string): Promise<void> => {
   try {
     await fetch(`/api/${boardKey}/ng-ids`, {
@@ -13,12 +10,21 @@ export const addSharedNgId = async (boardKey: string, ngId: string): Promise<voi
   }
 };
 
-export const deleteSharedNgId = async (boardKey: string, ngId: string): Promise<void> => {
-  try {
-    await fetch(`/api/${boardKey}/ng-ids/${encodeURIComponent(ngId)}`, {
-      method: "DELETE",
-    });
-  } catch (e) {
-    console.error("[sharedNgId] delete failed", e);
+// Mirrors MAX_NG_IDS_PER_DELETE in routes/ng_id.rs.
+const DELETE_BATCH_SIZE = 200;
+
+export const deleteSharedNgIds = async (boardKey: string, ngIds: string[]): Promise<void> => {
+  for (let i = 0; i < ngIds.length; i += DELETE_BATCH_SIZE) {
+    const batch = ngIds.slice(i, i + DELETE_BATCH_SIZE);
+
+    try {
+      await fetch(`/api/${boardKey}/ng-ids`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ng_ids: batch }),
+      });
+    } catch (e) {
+      console.error("[sharedNgId] delete failed", e);
+    }
   }
 };

--- a/eddist-server/client-v2/app/components/NGContextMenu.tsx
+++ b/eddist-server/client-v2/app/components/NGContextMenu.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef } from "react";
+import { addSharedNgId } from "~/api-client/ng_id";
 import { type NGCategory, useNGWords } from "~/contexts/NGWordsContext";
 import { useToast } from "~/contexts/ToastContext";
 
 interface NGContextMenuProps {
   x: number;
   y: number;
+  boardKey: string;
   onClose: () => void;
   options: {
     label: string;
@@ -20,7 +22,14 @@ interface NGContextMenuProps {
   }[];
 }
 
-export const NGContextMenu = ({ x, y, onClose, options, actions = [] }: NGContextMenuProps) => {
+export const NGContextMenu = ({
+  x,
+  y,
+  boardKey,
+  onClose,
+  options,
+  actions = [],
+}: NGContextMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
   const { addRule } = useNGWords();
   const { showToast } = useToast();
@@ -118,12 +127,21 @@ export const NGContextMenu = ({ x, y, onClose, options, actions = [] }: NGContex
     hideMode?: "hidden" | "collapsed",
   ) => {
     try {
+      // NG IDs from the response list are shared with the server; stamp the board
+      // key so the settings dialog can retract them later.
+      const isSharedNgId = category === "response.authorIds";
+
       addRule(category, {
         pattern: value,
         matchType: "partial",
         enabled: true,
         ...(hideMode ? { hideMode } : {}),
+        ...(isSharedNgId ? { sharedBoardKey: boardKey } : {}),
       });
+
+      if (isSharedNgId) {
+        void addSharedNgId(boardKey, value);
+      }
 
       // Visual feedback
       showToast(`NGワードに追加: ${value}`, "success");

--- a/eddist-server/client-v2/app/components/NGContextMenu.tsx
+++ b/eddist-server/client-v2/app/components/NGContextMenu.tsx
@@ -31,7 +31,7 @@ export const NGContextMenu = ({
   actions = [],
 }: NGContextMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
-  const { addRule } = useNGWords();
+  const { config, addRule } = useNGWords();
   const { showToast } = useToast();
 
   // Truncate long text for display
@@ -129,7 +129,15 @@ export const NGContextMenu = ({
     try {
       // NG IDs from the response list are shared with the server; stamp the board
       // key so the settings dialog can retract them later.
-      const isSharedNgId = category === "response.authorIds";
+      // A rule can only carry one board key, so if this pattern is already shared with
+      // another board, leave it alone: sharing it here too would record a contribution
+      // that no rule deletion could retract.
+      const existing =
+        category === "response.authorIds"
+          ? config.response.authorIds.find((r) => r.pattern === value && r.matchType === "partial")
+          : undefined;
+      const isSharedNgId =
+        category === "response.authorIds" && (existing?.sharedBoardKey ?? boardKey) === boardKey;
 
       addRule(category, {
         pattern: value,

--- a/eddist-server/client-v2/app/components/NGContextMenu.tsx
+++ b/eddist-server/client-v2/app/components/NGContextMenu.tsx
@@ -127,9 +127,8 @@ export const NGContextMenu = ({
     hideMode?: "hidden" | "collapsed",
   ) => {
     try {
-      // A rule carries one board key, so if this pattern is already shared with
-      // another board, leave it alone: sharing it here too would record a
-      // contribution that no rule deletion could retract.
+      // A rule holds one board key, so re-sharing a pattern already shared with
+      // another board would record a contribution nothing could retract.
       const existing =
         category === "response.authorIds"
           ? config.response.authorIds.find((r) => r.pattern === value && r.matchType === "partial")

--- a/eddist-server/client-v2/app/components/NGContextMenu.tsx
+++ b/eddist-server/client-v2/app/components/NGContextMenu.tsx
@@ -127,11 +127,9 @@ export const NGContextMenu = ({
     hideMode?: "hidden" | "collapsed",
   ) => {
     try {
-      // NG IDs from the response list are shared with the server; stamp the board
-      // key so the settings dialog can retract them later.
-      // A rule can only carry one board key, so if this pattern is already shared with
-      // another board, leave it alone: sharing it here too would record a contribution
-      // that no rule deletion could retract.
+      // A rule carries one board key, so if this pattern is already shared with
+      // another board, leave it alone: sharing it here too would record a
+      // contribution that no rule deletion could retract.
       const existing =
         category === "response.authorIds"
           ? config.response.authorIds.find((r) => r.pattern === value && r.matchType === "partial")

--- a/eddist-server/client-v2/app/components/NGRuleSection.tsx
+++ b/eddist-server/client-v2/app/components/NGRuleSection.tsx
@@ -83,6 +83,10 @@ export const NGRuleSection = ({
   });
 
   const handleStartEdit = (rule: NGRule) => {
+    // Shared NG IDs are delete-only: editing the pattern would leave the contribution
+    // recorded under the original pattern with no rule left to retract it.
+    if (rule.sharedBoardKey) return;
+
     setEditingId(rule.id);
     editReset({
       pattern: rule.pattern,
@@ -285,14 +289,16 @@ export const NGRuleSection = ({
                     </div>
                   </div>
                   <div className="flex gap-1 ml-2 shrink-0">
-                    <button
-                      onClick={() => handleStartEdit(rule)}
-                      className="text-blue-500 hover:text-blue-700 p-2 rounded hover:bg-blue-50 dark:hover:bg-blue-900 transition-colors"
-                      type="button"
-                      title="編集"
-                    >
-                      <HiPencil className="w-4 h-4" />
-                    </button>
+                    {!rule.sharedBoardKey && (
+                      <button
+                        onClick={() => handleStartEdit(rule)}
+                        className="text-blue-500 hover:text-blue-700 p-2 rounded hover:bg-blue-50 dark:hover:bg-blue-900 transition-colors"
+                        type="button"
+                        title="編集"
+                      >
+                        <HiPencil className="w-4 h-4" />
+                      </button>
+                    )}
                     <button
                       onClick={() => onRemove(rule.id)}
                       className="text-red-500 hover:text-red-700 text-sm px-2 py-1 rounded hover:bg-red-50 dark:hover:bg-red-900 transition-colors"

--- a/eddist-server/client-v2/app/components/NGRuleSection.tsx
+++ b/eddist-server/client-v2/app/components/NGRuleSection.tsx
@@ -12,6 +12,7 @@ interface NGRuleFormData {
 
 interface NGRuleSectionProps {
   title: string;
+  description?: string;
   rules: NGRule[];
   onAdd: (rule: Omit<NGRule, "id">) => void;
   onUpdate: (ruleId: string, updates: Partial<Omit<NGRule, "id">>) => void;
@@ -23,6 +24,7 @@ interface NGRuleSectionProps {
 
 export const NGRuleSection = ({
   title,
+  description,
   rules,
   onAdd,
   onUpdate,
@@ -110,6 +112,9 @@ export const NGRuleSection = ({
   return (
     <div className="mb-6 border-b border-gray-200 dark:border-gray-700 pb-4 last:border-b-0 dark:text-gray-100">
       <h3 className="text-lg font-semibold mb-3">{title}</h3>
+      {description && (
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{description}</p>
+      )}
 
       {/* Add new rule */}
       <form onSubmit={handleAdd} className="mb-4">

--- a/eddist-server/client-v2/app/components/NGRuleSection.tsx
+++ b/eddist-server/client-v2/app/components/NGRuleSection.tsx
@@ -12,7 +12,6 @@ interface NGRuleFormData {
 
 interface NGRuleSectionProps {
   title: string;
-  description?: string;
   rules: NGRule[];
   onAdd: (rule: Omit<NGRule, "id">) => void;
   onUpdate: (ruleId: string, updates: Partial<Omit<NGRule, "id">>) => void;
@@ -24,7 +23,6 @@ interface NGRuleSectionProps {
 
 export const NGRuleSection = ({
   title,
-  description,
   rules,
   onAdd,
   onUpdate,
@@ -83,8 +81,7 @@ export const NGRuleSection = ({
   });
 
   const handleStartEdit = (rule: NGRule) => {
-    // Shared NG IDs are delete-only: editing the pattern would leave the contribution
-    // recorded under the original pattern with no rule left to retract it.
+    // Editing the pattern would strand the contribution under the old one.
     if (rule.sharedBoardKey) return;
 
     setEditingId(rule.id);
@@ -116,9 +113,6 @@ export const NGRuleSection = ({
   return (
     <div className="mb-6 border-b border-gray-200 dark:border-gray-700 pb-4 last:border-b-0 dark:text-gray-100">
       <h3 className="text-lg font-semibold mb-3">{title}</h3>
-      {description && (
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{description}</p>
-      )}
 
       {/* Add new rule */}
       <form onSubmit={handleAdd} className="mb-4">

--- a/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
+++ b/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { FaDesktop, FaMoon, FaSun } from "react-icons/fa";
 import { HiInformationCircle } from "react-icons/hi";
 import { useRevalidator } from "react-router";
+import { deleteSharedNgId } from "~/api-client/ng_id";
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useTheme } from "~/contexts/ThemeContext";
 import { parseCookie } from "~/utils/cookie";
@@ -141,12 +142,34 @@ export const NGWordsSettingsModal = ({
 }: NGWordsSettingsModalProps) => {
   const { config, addRule, updateRule, removeRule, toggleRule, clearAllRules } = useNGWords();
 
+  // Removing a synced response 投稿者ID rule also retracts its shared NG ID.
+  const removeResponseAuthorId = (ruleId: string) => {
+    const rule = config.response.authorIds.find((r) => r.id === ruleId);
+    if (rule?.sharedBoardKey) {
+      void deleteSharedNgId(rule.sharedBoardKey, rule.pattern);
+    }
+    removeRule("response.authorIds", ruleId);
+  };
+
+  const handleClearAll = () => {
+    if (!window.confirm("すべてのNG設定をクリアしますか？\nこの操作は取り消せません。")) {
+      return;
+    }
+    // Retract synced shared NG IDs before wiping local config.
+    for (const rule of config.response.authorIds) {
+      if (rule.sharedBoardKey) {
+        void deleteSharedNgId(rule.sharedBoardKey, rule.pattern);
+      }
+    }
+    clearAllRules();
+  };
+
   return (
     <Modal show={open} size="5xl" onClose={() => setOpen(false)} dismissible>
       <ModalHeader className="border-gray-200 dark:border-gray-700">
         <div className="flex items-center gap-2">
           <span className="lg:text-2xl">設定</span>
-          <Tooltip content="この設定はローカルストレージに保存されます">
+          <Tooltip content="この設定は端末内（ローカルストレージ）に保存されます。ただしレス一覧から追加したNG IDはサーバーにも共有されます。">
             <HiInformationCircle className="w-5 h-5 text-gray-400 hover:text-gray-600 cursor-help" />
           </Tooltip>
         </div>
@@ -190,7 +213,7 @@ export const NGWordsSettingsModal = ({
                     rules={config.response.authorIds}
                     onAdd={(rule) => addRule("response.authorIds", rule)}
                     onUpdate={(id, updates) => updateRule("response.authorIds", id, updates)}
-                    onRemove={(id) => removeRule("response.authorIds", id)}
+                    onRemove={removeResponseAuthorId}
                     onToggle={(id) => toggleRule("response.authorIds", id)}
                     isResponseRule={true}
                   />
@@ -241,14 +264,7 @@ export const NGWordsSettingsModal = ({
         />
       </ModalBody>
       <ModalFooter className="flex justify-between mt-6 border-t border-gray-200 dark:border-gray-700">
-        <Button
-          color="gray"
-          onClick={() => {
-            if (window.confirm("すべてのNG設定をクリアしますか？\nこの操作は取り消せません。")) {
-              clearAllRules();
-            }
-          }}
-        >
+        <Button color="gray" onClick={handleClearAll}>
           すべてクリア
         </Button>
         <Button onClick={() => setOpen(false)}>閉じる</Button>

--- a/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
+++ b/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
@@ -169,7 +169,7 @@ export const NGWordsSettingsModal = ({
       <ModalHeader className="border-gray-200 dark:border-gray-700">
         <div className="flex items-center gap-2">
           <span className="lg:text-2xl">設定</span>
-          <Tooltip content="この設定は端末内（ローカルストレージ）に保存されます。ただしレス一覧から追加したNG IDはサーバーにも共有されます。">
+          <Tooltip content="この設定は端末内（ローカルストレージ）に保存されます。">
             <HiInformationCircle className="w-5 h-5 text-gray-400 hover:text-gray-600 cursor-help" />
           </Tooltip>
         </div>

--- a/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
+++ b/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { FaDesktop, FaMoon, FaSun } from "react-icons/fa";
 import { HiInformationCircle } from "react-icons/hi";
 import { useRevalidator } from "react-router";
-import { deleteSharedNgId } from "~/api-client/ng_id";
+import { deleteSharedNgIds } from "~/api-client/ng_id";
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useTheme } from "~/contexts/ThemeContext";
 import { parseCookie } from "~/utils/cookie";
@@ -142,11 +142,10 @@ export const NGWordsSettingsModal = ({
 }: NGWordsSettingsModalProps) => {
   const { config, addRule, updateRule, removeRule, toggleRule, clearAllRules } = useNGWords();
 
-  // Removing a synced response 投稿者ID rule also retracts its shared NG ID.
   const removeResponseAuthorId = (ruleId: string) => {
     const rule = config.response.authorIds.find((r) => r.id === ruleId);
     if (rule?.sharedBoardKey) {
-      void deleteSharedNgId(rule.sharedBoardKey, rule.pattern);
+      void deleteSharedNgIds(rule.sharedBoardKey, [rule.pattern]);
     }
     removeRule("response.authorIds", ruleId);
   };
@@ -155,12 +154,19 @@ export const NGWordsSettingsModal = ({
     if (!window.confirm("すべてのNG設定をクリアしますか？\nこの操作は取り消せません。")) {
       return;
     }
-    // Retract synced shared NG IDs before wiping local config.
+
+    const byBoardKey = new Map<string, string[]>();
     for (const rule of config.response.authorIds) {
       if (rule.sharedBoardKey) {
-        void deleteSharedNgId(rule.sharedBoardKey, rule.pattern);
+        const patterns = byBoardKey.get(rule.sharedBoardKey) ?? [];
+        patterns.push(rule.pattern);
+        byBoardKey.set(rule.sharedBoardKey, patterns);
       }
     }
+    for (const [boardKey, patterns] of byBoardKey) {
+      void deleteSharedNgIds(boardKey, patterns);
+    }
+
     clearAllRules();
   };
 

--- a/eddist-server/client-v2/app/contexts/NGWordsContext.tsx
+++ b/eddist-server/client-v2/app/contexts/NGWordsContext.tsx
@@ -210,7 +210,22 @@ export const NGWordsProvider = ({ children }: { children: ReactNode }) => {
       id: isBrowser && crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`,
     };
 
-    setConfig((prev) => updateRulesByCategory(prev, category, (rules) => [...rules, newRule]));
+    setConfig((prev) =>
+      updateRulesByCategory(prev, category, (rules) => {
+        const existing = rules.find(
+          (r) => r.pattern === newRule.pattern && r.matchType === newRule.matchType,
+        );
+        if (!existing) {
+          return [...rules, newRule];
+        }
+        if (!newRule.sharedBoardKey || existing.sharedBoardKey) {
+          return rules;
+        }
+        return rules.map((r) =>
+          r.id === existing.id ? { ...r, sharedBoardKey: newRule.sharedBoardKey } : r,
+        );
+      }),
+    );
   }, []);
 
   const updateRule = useCallback(

--- a/eddist-server/client-v2/app/contexts/NGWordsContext.tsx
+++ b/eddist-server/client-v2/app/contexts/NGWordsContext.tsx
@@ -19,6 +19,8 @@ export interface NGRule {
   matchType: "partial" | "regex";
   enabled: boolean;
   hideMode?: "hidden" | "collapsed";
+  // Set only for rules added from the response-list context menu (shared NG ID).
+  sharedBoardKey?: string;
 }
 
 export interface NGWordsConfig {

--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -519,6 +519,7 @@ const ThreadListPage = ({
         <NGContextMenu
           x={menuState.x}
           y={menuState.y}
+          boardKey={params.boardKey ?? ""}
           onClose={closeMenu}
           actions={[
             {

--- a/eddist-server/client-v2/app/routes/ThreadPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadPage.tsx
@@ -570,6 +570,7 @@ const ThreadPage = ({
         <NGContextMenu
           x={menuState.x}
           y={menuState.y}
+          boardKey={params.boardKey ?? ""}
           onClose={closeMenu}
           options={(() => {
             if (contextMenuType === "authorId") {

--- a/eddist-server/src/app.rs
+++ b/eddist-server/src/app.rs
@@ -5,7 +5,7 @@ use axum::{
     body::{Body, Bytes},
     extract::{MatchedPath, Path, State},
     response::{IntoResponse, Redirect, Response},
-    routing::{get, post},
+    routing::{delete, get, post},
 };
 use axum_prometheus::PrometheusMetricLayer;
 use eddist_core::domain::board::{BoardInfo, validate_board_key};
@@ -36,6 +36,7 @@ use crate::{
         auth_code::{get_auth_code, post_auth_code},
         bbs_cgi::post_bbs_cgi,
         dat_routing::{get_dat_txt, get_kako_dat_txt},
+        ng_id::{delete_ng_id, post_ng_id},
         notice::{get_latest_notices, get_notice_by_slug, get_notices_paginated},
         re_auth::{get_re_auth, post_re_auth},
         safe_mode::get_unsafe_thread_ids,
@@ -268,6 +269,8 @@ pub fn create_app(app_state: AppState, conn_mgr: redis::aio::ConnectionManager) 
             "/api/{boardKey}/unsafe-thread-ids",
             get(get_unsafe_thread_ids),
         )
+        .route("/api/{boardKey}/ng-ids", post(post_ng_id))
+        .route("/api/{boardKey}/ng-ids/{ngId}", delete(delete_ng_id))
         .nest("/user", user_routes())
         .route(
             "/{boardKey}",

--- a/eddist-server/src/app.rs
+++ b/eddist-server/src/app.rs
@@ -5,7 +5,7 @@ use axum::{
     body::{Body, Bytes},
     extract::{MatchedPath, Path, State},
     response::{IntoResponse, Redirect, Response},
-    routing::{delete, get, post},
+    routing::{get, post},
 };
 use axum_prometheus::PrometheusMetricLayer;
 use eddist_core::domain::board::{BoardInfo, validate_board_key};
@@ -37,7 +37,7 @@ use crate::{
         auth_code::{get_auth_code, post_auth_code},
         bbs_cgi::post_bbs_cgi,
         dat_routing::{get_dat_txt, get_kako_dat_txt},
-        ng_id::{delete_ng_id, post_ng_id},
+        ng_id::{delete_ng_ids, post_ng_id},
         notice::{get_latest_notices, get_notice_by_slug, get_notices_paginated},
         re_auth::{get_re_auth, post_re_auth},
         safe_mode::get_unsafe_thread_ids,
@@ -233,8 +233,10 @@ pub fn create_app(app_state: AppState, conn_mgr: redis::aio::ConnectionManager) 
     };
 
     let ng_id_routes = Router::new()
-        .route("/api/{boardKey}/ng-ids", post(post_ng_id))
-        .route("/api/{boardKey}/ng-ids/{ngId}", delete(delete_ng_id))
+        .route(
+            "/api/{boardKey}/ng-ids",
+            post(post_ng_id).delete(delete_ng_ids),
+        )
         .route_layer(axum::middleware::from_fn_with_state(
             app_state.clone(),
             ng_id_rate_limit_middleware,

--- a/eddist-server/src/app.rs
+++ b/eddist-server/src/app.rs
@@ -19,6 +19,7 @@ use tracing::{Span, info_span};
 
 use crate::{
     middleware::{
+        ng_id_rate_limit::ng_id_rate_limit_middleware,
         not_found_rate_limit::{NotFoundPenaltyCache, not_found_rate_limit_middleware},
         user_restriction::user_restriction_middleware,
     },
@@ -231,6 +232,14 @@ pub fn create_app(app_state: AppState, conn_mgr: redis::aio::ConnectionManager) 
         (layer, Some(handle))
     };
 
+    let ng_id_routes = Router::new()
+        .route("/api/{boardKey}/ng-ids", post(post_ng_id))
+        .route("/api/{boardKey}/ng-ids/{ngId}", delete(delete_ng_id))
+        .route_layer(axum::middleware::from_fn_with_state(
+            app_state.clone(),
+            ng_id_rate_limit_middleware,
+        ));
+
     let app = Router::new()
         .route("/health-check", get(health_check))
         .route(
@@ -269,8 +278,7 @@ pub fn create_app(app_state: AppState, conn_mgr: redis::aio::ConnectionManager) 
             "/api/{boardKey}/unsafe-thread-ids",
             get(get_unsafe_thread_ids),
         )
-        .route("/api/{boardKey}/ng-ids", post(post_ng_id))
-        .route("/api/{boardKey}/ng-ids/{ngId}", delete(delete_ng_id))
+        .merge(ng_id_routes)
         .nest("/user", user_routes())
         .route(
             "/{boardKey}",

--- a/eddist-server/src/lib.rs
+++ b/eddist-server/src/lib.rs
@@ -52,6 +52,7 @@ mod routes {
     pub mod auth_code;
     pub mod bbs_cgi;
     pub mod dat_routing;
+    pub mod ng_id;
     pub mod notice;
     pub mod re_auth;
     pub mod safe_mode;

--- a/eddist-server/src/middleware/mod.rs
+++ b/eddist-server/src/middleware/mod.rs
@@ -1,2 +1,3 @@
+pub mod ng_id_rate_limit;
 pub mod not_found_rate_limit;
 pub mod user_restriction;

--- a/eddist-server/src/middleware/ng_id_rate_limit.rs
+++ b/eddist-server/src/middleware/ng_id_rate_limit.rs
@@ -1,0 +1,70 @@
+use std::sync::LazyLock;
+
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use redis::Script;
+
+use eddist_core::{domain::ip_addr::ReducedIpAddr, redis_keys::shared_ng_id_ip_rate_limit_key};
+
+use crate::{AppState, utils::get_origin_ip};
+
+const NG_ID_WINDOW_SECS: i64 = 60;
+
+/// Sized for すべてクリア, which fires one unbatched DELETE per stored rule -
+/// a legitimate burst far larger than interactive use.
+const NG_ID_THRESHOLD: i64 = 300;
+
+/// One script so `INCR` and `EXPIRE` cannot be split: a failed `EXPIRE` would
+/// leave a key that never expires.
+static RATE_LIMIT_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
+    Script::new(
+        r"
+        local count = redis.call('INCR', KEYS[1])
+        if count == 1 then
+            redis.call('EXPIRE', KEYS[1], ARGV[1])
+        end
+        return count
+        ",
+    )
+});
+
+/// Keyed on the source, not the authed token: `post_ng_id`'s per-token limit
+/// needs the DB lookup it would be protecting, and `delete_ng_id` has none.
+pub async fn ng_id_rate_limit_middleware(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let Some(ip) = get_origin_ip(request.headers()) else {
+        return next.run(request).await;
+    };
+    let ip = ReducedIpAddr::from(ip.to_string()).to_string();
+    let key = shared_ng_id_ip_rate_limit_key(&ip);
+
+    let mut redis_conn = state.redis_conn.clone();
+    let count: i64 = match RATE_LIMIT_SCRIPT
+        .key(&key)
+        .arg(NG_ID_WINDOW_SECS)
+        .invoke_async(&mut redis_conn)
+        .await
+    {
+        Ok(count) => count,
+        Err(e) => {
+            tracing::error!("Failed to check shared NG ID rate limit for {ip}: {e}");
+            return next.run(request).await;
+        }
+    };
+
+    if count > NG_ID_THRESHOLD {
+        tracing::warn!(
+            "IP {ip} exceeded shared NG ID rate limit ({count} requests within {NG_ID_WINDOW_SECS}s); rejecting with 429"
+        );
+        return (StatusCode::TOO_MANY_REQUESTS, "Too Many Requests").into_response();
+    }
+
+    next.run(request).await
+}

--- a/eddist-server/src/middleware/ng_id_rate_limit.rs
+++ b/eddist-server/src/middleware/ng_id_rate_limit.rs
@@ -1,39 +1,21 @@
-use std::sync::LazyLock;
-
 use axum::{
     extract::{Request, State},
     http::StatusCode,
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use redis::Script;
 
 use eddist_core::{domain::ip_addr::ReducedIpAddr, redis_keys::shared_ng_id_ip_rate_limit_key};
 
-use crate::{AppState, utils::get_origin_ip};
+use crate::{
+    AppState,
+    utils::{get_origin_ip, incr_fixed_window},
+};
 
 const NG_ID_WINDOW_SECS: i64 = 60;
 
-/// Sized for すべてクリア, which fires one unbatched DELETE per stored rule -
-/// a legitimate burst far larger than interactive use.
-const NG_ID_THRESHOLD: i64 = 300;
+const NG_ID_THRESHOLD: i64 = 60;
 
-/// One script so `INCR` and `EXPIRE` cannot be split: a failed `EXPIRE` would
-/// leave a key that never expires.
-static RATE_LIMIT_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
-    Script::new(
-        r"
-        local count = redis.call('INCR', KEYS[1])
-        if count == 1 then
-            redis.call('EXPIRE', KEYS[1], ARGV[1])
-        end
-        return count
-        ",
-    )
-});
-
-/// Keyed on the source, not the authed token: `post_ng_id`'s per-token limit
-/// needs the DB lookup it would be protecting, and `delete_ng_id` has none.
 pub async fn ng_id_rate_limit_middleware(
     State(state): State<AppState>,
     request: Request,
@@ -46,12 +28,7 @@ pub async fn ng_id_rate_limit_middleware(
     let key = shared_ng_id_ip_rate_limit_key(&ip);
 
     let mut redis_conn = state.redis_conn.clone();
-    let count: i64 = match RATE_LIMIT_SCRIPT
-        .key(&key)
-        .arg(NG_ID_WINDOW_SECS)
-        .invoke_async(&mut redis_conn)
-        .await
-    {
+    let count = match incr_fixed_window(&mut redis_conn, &key, NG_ID_WINDOW_SECS).await {
         Ok(count) => count,
         Err(e) => {
             tracing::error!("Failed to check shared NG ID rate limit for {ip}: {e}");

--- a/eddist-server/src/routes/ng_id.rs
+++ b/eddist-server/src/routes/ng_id.rs
@@ -13,7 +13,10 @@ use redis::AsyncCommands as _;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-use crate::AppState;
+use crate::{
+    AppState,
+    services::{AppService, edge_token_validation_service::EdgeTokenValidationServiceInput},
+};
 
 // TTL for a shared NG ID entry, refreshed on every add.
 const SHARED_NG_ID_TTL_SECS: i64 = 3 * 24 * 60 * 60;
@@ -40,6 +43,32 @@ fn hash_edge_token(token: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+/// Resolves the caller's `edge-token` cookie to the hash stored in Redis.
+///
+/// The cookie is attacker-controlled, so it is validated against `authed_tokens`
+/// first: without that, any client could mint unlimited distinct hashes, which are
+/// both the unit the contributor sets count and the rate limit's key.
+async fn resolve_contributor_hash(state: &AppState, jar: &CookieJar) -> Result<String, Response> {
+    let Some(edge_token) = jar.get("edge-token").map(|c| c.value().to_string()) else {
+        return Err(empty(401));
+    };
+
+    let authed_token = state
+        .get_container()
+        .edge_token_validation()
+        .execute(EdgeTokenValidationServiceInput { edge_token })
+        .await;
+
+    match authed_token {
+        Ok(Some(token)) => Ok(hash_edge_token(&token.token)),
+        Ok(None) => Err(empty(401)),
+        Err(e) => {
+            log::error!("Failed to validate edge-token for shared NG ID: {e:?}");
+            Err(empty(500))
+        }
+    }
 }
 
 fn is_valid_ng_id(ng_id: &str) -> bool {
@@ -69,9 +98,6 @@ pub async fn post_ng_id(
     jar: CookieJar,
     Json(req): Json<AddNgIdRequest>,
 ) -> Response {
-    let Some(edge_token) = jar.get("edge-token").map(|c| c.value().to_string()) else {
-        return empty(401);
-    };
     if validate_board_key(&board_key).is_err() {
         return empty(404);
     }
@@ -79,8 +105,12 @@ pub async fn post_ng_id(
         return empty(400);
     }
 
+    let hash = match resolve_contributor_hash(&state, &jar).await {
+        Ok(hash) => hash,
+        Err(resp) => return resp,
+    };
+
     let key = shared_ng_id_key(&board_key, &req.ng_id);
-    let hash = hash_edge_token(&edge_token);
     let mut conn = state.redis_conn.clone();
 
     match within_shared_ng_id_rate_limit(&mut conn, &hash).await {
@@ -110,9 +140,6 @@ pub async fn delete_ng_id(
     Path((board_key, ng_id)): Path<(String, String)>,
     jar: CookieJar,
 ) -> Response {
-    let Some(edge_token) = jar.get("edge-token").map(|c| c.value().to_string()) else {
-        return empty(401);
-    };
     if validate_board_key(&board_key).is_err() {
         return empty(404);
     }
@@ -120,8 +147,12 @@ pub async fn delete_ng_id(
         return empty(400);
     }
 
+    let hash = match resolve_contributor_hash(&state, &jar).await {
+        Ok(hash) => hash,
+        Err(resp) => return resp,
+    };
+
     let key = shared_ng_id_key(&board_key, &ng_id);
-    let hash = hash_edge_token(&edge_token);
     let mut conn = state.redis_conn.clone();
 
     // SREM is a no-op if the member/key is missing.

--- a/eddist-server/src/routes/ng_id.rs
+++ b/eddist-server/src/routes/ng_id.rs
@@ -1,0 +1,134 @@
+use axum::{
+    Json,
+    body::Body,
+    extract::{Path, State},
+    response::Response,
+};
+use axum_extra::extract::CookieJar;
+use eddist_core::{
+    domain::board::validate_board_key,
+    redis_keys::{shared_ng_id_key, shared_ng_id_rate_limit_key},
+};
+use redis::AsyncCommands as _;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use crate::AppState;
+
+// TTL for a shared NG ID entry, refreshed on every add.
+const SHARED_NG_ID_TTL_SECS: i64 = 3 * 24 * 60 * 60;
+
+const MAX_NG_ID_LEN: usize = 64;
+
+// Max shared NG ID adds per authed token per rolling day.
+const SHARED_NG_ID_RATE_LIMIT: i64 = 25;
+const SHARED_NG_ID_RATE_LIMIT_WINDOW_SECS: i64 = 24 * 60 * 60;
+
+#[derive(Deserialize)]
+pub struct AddNgIdRequest {
+    pub ng_id: String,
+}
+
+fn empty(status: u16) -> Response {
+    Response::builder()
+        .status(status)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn hash_edge_token(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn is_valid_ng_id(ng_id: &str) -> bool {
+    !ng_id.is_empty()
+        && ng_id.len() <= MAX_NG_ID_LEN
+        && !ng_id.contains(':')
+        && !ng_id.chars().any(|c| c.is_control())
+}
+
+async fn within_shared_ng_id_rate_limit(
+    conn: &mut redis::aio::ConnectionManager,
+    token_hash: &str,
+) -> redis::RedisResult<bool> {
+    let rate_key = shared_ng_id_rate_limit_key(token_hash);
+    let count: i64 = conn.incr(&rate_key, 1).await?;
+    if count == 1 {
+        conn.expire::<_, ()>(&rate_key, SHARED_NG_ID_RATE_LIMIT_WINDOW_SECS)
+            .await?;
+    }
+    Ok(count <= SHARED_NG_ID_RATE_LIMIT)
+}
+
+// POST /api/{boardKey}/ng-ids — record that the caller marked `ng_id` as NG.
+pub async fn post_ng_id(
+    State(state): State<AppState>,
+    Path(board_key): Path<String>,
+    jar: CookieJar,
+    Json(req): Json<AddNgIdRequest>,
+) -> Response {
+    let Some(edge_token) = jar.get("edge-token").map(|c| c.value().to_string()) else {
+        return empty(401);
+    };
+    if validate_board_key(&board_key).is_err() {
+        return empty(404);
+    }
+    if !is_valid_ng_id(&req.ng_id) {
+        return empty(400);
+    }
+
+    let key = shared_ng_id_key(&board_key, &req.ng_id);
+    let hash = hash_edge_token(&edge_token);
+    let mut conn = state.redis_conn.clone();
+
+    match within_shared_ng_id_rate_limit(&mut conn, &hash).await {
+        Ok(true) => {}
+        Ok(false) => return empty(429),
+        Err(e) => {
+            log::error!("Failed to check shared NG ID rate limit: {e:?}");
+            return empty(500);
+        }
+    }
+
+    if let Err(e) = conn.sadd::<_, _, ()>(&key, &hash).await {
+        log::error!("Failed to add shared NG ID to Redis: {e:?}");
+        return empty(500);
+    }
+    if let Err(e) = conn.expire::<_, ()>(&key, SHARED_NG_ID_TTL_SECS).await {
+        log::error!("Failed to set TTL on shared NG ID: {e:?}");
+        return empty(500);
+    }
+
+    empty(204)
+}
+
+// DELETE /api/{boardKey}/ng-ids/{ngId} — retract the caller's shared NG ID mark.
+pub async fn delete_ng_id(
+    State(state): State<AppState>,
+    Path((board_key, ng_id)): Path<(String, String)>,
+    jar: CookieJar,
+) -> Response {
+    let Some(edge_token) = jar.get("edge-token").map(|c| c.value().to_string()) else {
+        return empty(401);
+    };
+    if validate_board_key(&board_key).is_err() {
+        return empty(404);
+    }
+    if !is_valid_ng_id(&ng_id) {
+        return empty(400);
+    }
+
+    let key = shared_ng_id_key(&board_key, &ng_id);
+    let hash = hash_edge_token(&edge_token);
+    let mut conn = state.redis_conn.clone();
+
+    // SREM is a no-op if the member/key is missing.
+    if let Err(e) = conn.srem::<_, _, ()>(&key, &hash).await {
+        log::error!("Failed to remove shared NG ID from Redis: {e:?}");
+        return empty(500);
+    }
+
+    empty(204)
+}

--- a/eddist-server/src/routes/ng_id.rs
+++ b/eddist-server/src/routes/ng_id.rs
@@ -18,12 +18,10 @@ use crate::{
     services::{AppService, edge_token_validation_service::EdgeTokenValidationServiceInput},
 };
 
-// TTL for a shared NG ID entry, refreshed on every add.
 const SHARED_NG_ID_TTL_SECS: i64 = 3 * 24 * 60 * 60;
 
 const MAX_NG_ID_LEN: usize = 64;
 
-// Max shared NG ID adds per authed token per rolling day.
 const SHARED_NG_ID_RATE_LIMIT: i64 = 25;
 const SHARED_NG_ID_RATE_LIMIT_WINDOW_SECS: i64 = 24 * 60 * 60;
 
@@ -91,7 +89,6 @@ async fn within_shared_ng_id_rate_limit(
     Ok(count <= SHARED_NG_ID_RATE_LIMIT)
 }
 
-// POST /api/{boardKey}/ng-ids — record that the caller marked `ng_id` as NG.
 pub async fn post_ng_id(
     State(state): State<AppState>,
     Path(board_key): Path<String>,
@@ -134,7 +131,6 @@ pub async fn post_ng_id(
     empty(204)
 }
 
-// DELETE /api/{boardKey}/ng-ids/{ngId} — retract the caller's shared NG ID mark.
 pub async fn delete_ng_id(
     State(state): State<AppState>,
     Path((board_key, ng_id)): Path<(String, String)>,

--- a/eddist-server/src/routes/ng_id.rs
+++ b/eddist-server/src/routes/ng_id.rs
@@ -9,18 +9,21 @@ use eddist_core::{
     domain::board::validate_board_key,
     redis_keys::{shared_ng_id_key, shared_ng_id_rate_limit_key},
 };
-use redis::AsyncCommands as _;
+use redis::{AsyncCommands as _, pipe};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 use crate::{
     AppState,
     services::{AppService, edge_token_validation_service::EdgeTokenValidationServiceInput},
+    utils::incr_fixed_window,
 };
 
 const SHARED_NG_ID_TTL_SECS: i64 = 3 * 24 * 60 * 60;
 
 const MAX_NG_ID_LEN: usize = 64;
+
+const MAX_NG_IDS_PER_DELETE: usize = 200;
 
 const SHARED_NG_ID_RATE_LIMIT: i64 = 25;
 const SHARED_NG_ID_RATE_LIMIT_WINDOW_SECS: i64 = 24 * 60 * 60;
@@ -28,6 +31,11 @@ const SHARED_NG_ID_RATE_LIMIT_WINDOW_SECS: i64 = 24 * 60 * 60;
 #[derive(Deserialize)]
 pub struct AddNgIdRequest {
     pub ng_id: String,
+}
+
+#[derive(Deserialize)]
+pub struct DeleteNgIdsRequest {
+    pub ng_ids: Vec<String>,
 }
 
 fn empty(status: u16) -> Response {
@@ -43,11 +51,6 @@ fn hash_edge_token(token: &str) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-/// Resolves the caller's `edge-token` cookie to the hash stored in Redis.
-///
-/// The cookie is attacker-controlled, so it is validated against `authed_tokens`
-/// first: without that, any client could mint unlimited distinct hashes, which are
-/// both the unit the contributor sets count and the rate limit's key.
 async fn resolve_contributor_hash(state: &AppState, jar: &CookieJar) -> Result<String, Response> {
     let Some(edge_token) = jar.get("edge-token").map(|c| c.value().to_string()) else {
         return Err(empty(401));
@@ -81,11 +84,8 @@ async fn within_shared_ng_id_rate_limit(
     token_hash: &str,
 ) -> redis::RedisResult<bool> {
     let rate_key = shared_ng_id_rate_limit_key(token_hash);
-    let count: i64 = conn.incr(&rate_key, 1).await?;
-    if count == 1 {
-        conn.expire::<_, ()>(&rate_key, SHARED_NG_ID_RATE_LIMIT_WINDOW_SECS)
-            .await?;
-    }
+    let count = incr_fixed_window(conn, &rate_key, SHARED_NG_ID_RATE_LIMIT_WINDOW_SECS).await?;
+
     Ok(count <= SHARED_NG_ID_RATE_LIMIT)
 }
 
@@ -131,15 +131,19 @@ pub async fn post_ng_id(
     empty(204)
 }
 
-pub async fn delete_ng_id(
+pub async fn delete_ng_ids(
     State(state): State<AppState>,
-    Path((board_key, ng_id)): Path<(String, String)>,
+    Path(board_key): Path<String>,
     jar: CookieJar,
+    Json(req): Json<DeleteNgIdsRequest>,
 ) -> Response {
     if validate_board_key(&board_key).is_err() {
         return empty(404);
     }
-    if !is_valid_ng_id(&ng_id) {
+    if req.ng_ids.is_empty() || req.ng_ids.len() > MAX_NG_IDS_PER_DELETE {
+        return empty(400);
+    }
+    if !req.ng_ids.iter().all(|ng_id| is_valid_ng_id(ng_id)) {
         return empty(400);
     }
 
@@ -148,12 +152,16 @@ pub async fn delete_ng_id(
         Err(resp) => return resp,
     };
 
-    let key = shared_ng_id_key(&board_key, &ng_id);
     let mut conn = state.redis_conn.clone();
 
-    // SREM is a no-op if the member/key is missing.
-    if let Err(e) = conn.srem::<_, _, ()>(&key, &hash).await {
-        log::error!("Failed to remove shared NG ID from Redis: {e:?}");
+    let mut pipe = pipe();
+    for ng_id in &req.ng_ids {
+        pipe.srem(shared_ng_id_key(&board_key, ng_id), &hash)
+            .ignore();
+    }
+
+    if let Err(e) = pipe.query_async::<()>(&mut conn).await {
+        log::error!("Failed to remove shared NG IDs from Redis: {e:?}");
         return empty(500);
     }
 

--- a/eddist-server/src/services.rs
+++ b/eddist-server/src/services.rs
@@ -2,6 +2,7 @@ use auth_with_code_service::AuthWithCodeService;
 use aws_sdk_s3::Client;
 use bind_token_to_user_service::BindTokenToUserService;
 use board_info_service::BoardInfoService;
+use edge_token_validation_service::EdgeTokenValidationService;
 use kako_thread_retrieval_service::KakoThreadRetrievalService;
 use list_boards_service::ListBoardsService;
 use metadent_thread_list_service::MetadentThreadListService;
@@ -41,6 +42,7 @@ pub(crate) mod auth_with_code_service;
 pub(crate) mod bind_token_to_user_service;
 pub(crate) mod board_info_service;
 pub mod captcha_config_cache;
+pub(crate) mod edge_token_validation_service;
 pub(crate) mod kako_thread_retrieval_service;
 pub(crate) mod list_boards_service;
 pub(crate) mod metadent_thread_list_service;
@@ -86,6 +88,7 @@ pub struct AppServiceContainer<
     auth_with_code: AuthWithCodeService<B, E>,
     reauth: ReAuthService<B>,
     board_info: BoardInfoService<B>,
+    edge_token_validation: EdgeTokenValidationService<B>,
     list_boards: ListBoardsService<B>,
     res_creation: ResCreationService<B, U, P, E>,
     thread_creation: ThreadCreationService<B, U, E>,
@@ -132,6 +135,7 @@ impl<
             ),
             reauth: ReAuthService::new(bbs_repo.clone(), redis_conn.clone()),
             board_info: BoardInfoService::new(bbs_repo.clone()),
+            edge_token_validation: EdgeTokenValidationService::new(bbs_repo.clone()),
             list_boards: ListBoardsService::new(bbs_repo.clone()),
             res_creation: ResCreationService::new(
                 bbs_repo.clone(),
@@ -203,6 +207,10 @@ impl<
 
     pub fn board_info(&self) -> &BoardInfoService<B> {
         &self.board_info
+    }
+
+    pub fn edge_token_validation(&self) -> &EdgeTokenValidationService<B> {
+        &self.edge_token_validation
     }
 
     pub fn res_creation(&self) -> &ResCreationService<B, U, P, E> {

--- a/eddist-server/src/services/edge_token_validation_service.rs
+++ b/eddist-server/src/services/edge_token_validation_service.rs
@@ -1,0 +1,38 @@
+use crate::{domain::authed_token::AuthedToken, repositories::bbs_repository::BbsRepository};
+
+use super::AppService;
+
+/// Resolves an `edge-token` cookie to its authed token, rejecting values that do
+/// not exist or are no longer valid.
+///
+/// Read-only endpoints use this rather than `BbsCgiAuthService::check_validity`,
+/// which is posting-specific: it mints a new token when the cookie is absent and
+/// reports its errors as auth-code challenges.
+#[derive(Clone)]
+pub struct EdgeTokenValidationService<T: BbsRepository>(T);
+
+impl<T: BbsRepository> EdgeTokenValidationService<T> {
+    pub fn new(repo: T) -> Self {
+        Self(repo)
+    }
+}
+
+pub struct EdgeTokenValidationServiceInput {
+    pub edge_token: String,
+}
+
+#[async_trait::async_trait]
+impl<T: BbsRepository> AppService<EdgeTokenValidationServiceInput, Option<AuthedToken>>
+    for EdgeTokenValidationService<T>
+{
+    async fn execute(
+        &self,
+        input: EdgeTokenValidationServiceInput,
+    ) -> anyhow::Result<Option<AuthedToken>> {
+        Ok(self
+            .0
+            .get_authed_token(&input.edge_token)
+            .await?
+            .filter(|token| token.validity))
+    }
+}

--- a/eddist-server/src/services/edge_token_validation_service.rs
+++ b/eddist-server/src/services/edge_token_validation_service.rs
@@ -2,12 +2,6 @@ use crate::{domain::authed_token::AuthedToken, repositories::bbs_repository::Bbs
 
 use super::AppService;
 
-/// Resolves an `edge-token` cookie to its authed token, rejecting values that do
-/// not exist or are no longer valid.
-///
-/// Read-only endpoints use this rather than `BbsCgiAuthService::check_validity`,
-/// which is posting-specific: it mints a new token when the cookie is absent and
-/// reports its errors as auth-code challenges.
 #[derive(Clone)]
 pub struct EdgeTokenValidationService<T: BbsRepository>(T);
 

--- a/eddist-server/src/utils.rs
+++ b/eddist-server/src/utils.rs
@@ -74,6 +74,24 @@ pub fn get_tinker(tinker: &str, secret: &str) -> Option<Tinker> {
     Some(tinker.patch_internal_level_if_missing(level))
 }
 
+pub async fn incr_fixed_window(
+    conn: &mut ::redis::aio::ConnectionManager,
+    key: &str,
+    window_secs: i64,
+) -> ::redis::RedisResult<i64> {
+    let (count,): (i64,) = ::redis::pipe()
+        .incr(key, 1)
+        .cmd("EXPIRE")
+        .arg(key)
+        .arg(window_secs)
+        .arg(::redis::ExpireOption::NX)
+        .ignore()
+        .query_async(conn)
+        .await?;
+
+    Ok(count)
+}
+
 #[async_trait::async_trait]
 pub trait TransactionRepository<T: Database> {
     async fn begin(&self) -> anyhow::Result<Transaction<'_, T>>;


### PR DESCRIPTION
Lay the write/storage groundwork for a future shared NG ID feature. When a user marks an author ID as NG from the response-list context menu, the signal is now sent to eddist-server and aggregated in Redis per board + per ID as a set of anonymized contributor tokens. Preparation only: nothing reads the data back into filtering yet (will migrate Redis -> DB later).

Server (eddist-server):
- Add redis_keys::shared_ng_id_key (shared_ng_id:{board_key}:{ng_id}) + test
- New routes/ng_id.rs: POST /api/{boardKey}/ng-ids and DELETE /api/{boardKey}/ng-ids/{ngId}
- Requires the edge-token cookie; stores SHA-256(edge_token) hex in a per-ID SET with a 3-day TTL (refreshed on add). Plain SHA-256 for anonymization only (edge-token is already high-entropy) - no salt/KDF, no new env var
- SADD/EXPIRE on add, SREM on delete (delete is a safe no-op if never synced)
- Register mod in lib.rs and routes in app.rs

Client (client-v2):
- New api-client/ng_id.ts best-effort add/deleteSharedNgId helpers
- NGRule gains optional sharedBoardKey, stamped only on context-menu adds so the settings dialog can retract the right board's contribution
- NGContextMenu takes a boardKey prop and syncs only response.authorIds adds; direct input in the settings dialog never syncs
- Settings dialog retracts synced NG IDs on individual delete and on clear-all
- Add helper text to the response author-ID section and update the header tooltip to reflect that context-menu NG IDs are shared with the server
