### PR TITLE
feat: allow keeping author_id visible when abone-ing a response

### DIFF
--- a/.sqlx/query-5260326bb083854c831907b95f8c674c6202fc5916d3d345bab5e8fdcdf2ab23.json
+++ b/.sqlx/query-5260326bb083854c831907b95f8c674c6202fc5916d3d345bab5e8fdcdf2ab23.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "SELECT\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                is_abone AS \"is_abone: bool\"\n            FROM responses WHERE thread_id = ?\n            ORDER BY res_order, id",
+  "query": "\n            SELECT\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                is_abone,\n                is_abone_keep_id,\n                authed_token_id AS \"authed_token_id: Uuid\",\n                client_info AS \"client_info: Json<ClientInfo>\"\n            FROM\n                responses\n            WHERE\n                thread_id = ?\n            ORDER BY res_order, id\n            ",
   "describe": {
     "columns": [
       {
@@ -50,11 +50,38 @@
       },
       {
         "ordinal": 5,
-        "name": "is_abone: bool",
+        "name": "is_abone",
         "type_info": {
           "type": "Tiny",
           "flags": "NOT_NULL",
           "max_size": 1
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "is_abone_keep_id",
+        "type_info": {
+          "type": "Tiny",
+          "flags": "NOT_NULL",
+          "max_size": 1
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "authed_token_id: Uuid",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
+          "max_size": 16
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "client_info: Json<ClientInfo>",
+        "type_info": {
+          "type": "Json",
+          "flags": "NOT_NULL | BLOB | BINARY | NO_DEFAULT_VALUE",
+          "max_size": 4294967295
         }
       }
     ],
@@ -67,8 +94,11 @@
       false,
       false,
       false,
+      false,
+      false,
+      false,
       false
     ]
   },
-  "hash": "bd66d745255ab8d2c837d3ba6505d0e7777711e71e3f7ae27320af8caa5128f9"
+  "hash": "5260326bb083854c831907b95f8c674c6202fc5916d3d345bab5e8fdcdf2ab23"
 }

--- a/.sqlx/query-772e2a4a349cb942d2752279f4b10bb90203a2a822bee1e2abfd4949e6874cc6.json
+++ b/.sqlx/query-772e2a4a349cb942d2752279f4b10bb90203a2a822bee1e2abfd4949e6874cc6.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "\n            SELECT\n                id,\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                ip_addr,\n                authed_token_id,\n                board_id,\n                thread_id,\n                is_abone,\n                client_info AS \"client_info!: Json<ClientInfo>\",\n                res_order\n            FROM\n                archived_responses\n            WHERE\n                thread_id = (\n                    SELECT\n                        id\n                    FROM\n                        archived_threads\n                    WHERE\n                        board_id = (\n                        SELECT\n                            id\n                        FROM\n                            boards\n                        WHERE\n                            board_key = ?\n                        )\n                    AND\n                        thread_number = ?\n                )\n            ORDER BY\n                res_order ASC, id ASC\n            ",
+  "query": "\n            SELECT\n                id,\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                ip_addr,\n                authed_token_id,\n                board_id,\n                thread_id,\n                is_abone,\n                0 AS \"is_abone_keep_id: i8\",\n                client_info AS \"client_info!: Json<ClientInfo>\",\n                res_order\n            FROM\n                archived_responses\n            WHERE\n                thread_id = (\n                    SELECT\n                        id\n                    FROM\n                        archived_threads\n                    WHERE\n                        board_id = (\n                        SELECT\n                            id\n                        FROM\n                            boards\n                        WHERE\n                            board_key = ?\n                        )\n                    AND\n                        thread_number = ?\n                )\n            ORDER BY\n                res_order ASC, id ASC\n            ",
   "describe": {
     "columns": [
       {
@@ -104,6 +104,15 @@
       },
       {
         "ordinal": 11,
+        "name": "is_abone_keep_id: i8",
+        "type_info": {
+          "type": "LongLong",
+          "flags": "NOT_NULL | BINARY",
+          "max_size": 2
+        }
+      },
+      {
+        "ordinal": 12,
         "name": "client_info!: Json<ClientInfo>",
         "type_info": {
           "type": "Json",
@@ -112,7 +121,7 @@
         }
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "res_order",
         "type_info": {
           "type": "Long",
@@ -137,8 +146,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "280dedcda4160f0a8e180c3379e552908f89825fd8e7b54544c627042b8fb1eb"
+  "hash": "772e2a4a349cb942d2752279f4b10bb90203a2a822bee1e2abfd4949e6874cc6"
 }

--- a/.sqlx/query-82d4320a02f26b9386fe7992c9a1a08a025fe0f6fcd6bb32c7ce9cfb52253a7e.json
+++ b/.sqlx/query-82d4320a02f26b9386fe7992c9a1a08a025fe0f6fcd6bb32c7ce9cfb52253a7e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "\n            SELECT\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                is_abone,\n                authed_token_id AS \"authed_token_id: Uuid\",\n                client_info AS \"client_info: Json<ClientInfo>\"\n            FROM\n                archived_responses\n            WHERE\n                thread_id = ?\n            ORDER BY res_order, id\n            ",
+  "query": "SELECT\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                is_abone AS \"is_abone: bool\",\n                is_abone_keep_id AS \"is_abone_keep_id: bool\"\n            FROM responses WHERE thread_id = ?\n            ORDER BY res_order, id",
   "describe": {
     "columns": [
       {
@@ -35,7 +35,7 @@
         "name": "created_at",
         "type_info": {
           "type": "Datetime",
-          "flags": "NOT_NULL | PRIMARY_KEY | BINARY | NO_DEFAULT_VALUE",
+          "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
           "max_size": 23
         }
       },
@@ -50,7 +50,7 @@
       },
       {
         "ordinal": 5,
-        "name": "is_abone",
+        "name": "is_abone: bool",
         "type_info": {
           "type": "Tiny",
           "flags": "NOT_NULL",
@@ -59,20 +59,11 @@
       },
       {
         "ordinal": 6,
-        "name": "authed_token_id: Uuid",
+        "name": "is_abone_keep_id: bool",
         "type_info": {
-          "type": "String",
-          "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
-          "max_size": 16
-        }
-      },
-      {
-        "ordinal": 7,
-        "name": "client_info: Json<ClientInfo>",
-        "type_info": {
-          "type": "Json",
-          "flags": "NOT_NULL | BLOB | BINARY | NO_DEFAULT_VALUE",
-          "max_size": 4294967295
+          "type": "Tiny",
+          "flags": "NOT_NULL",
+          "max_size": 1
         }
       }
     ],
@@ -86,9 +77,8 @@
       false,
       false,
       false,
-      false,
       false
     ]
   },
-  "hash": "5cb194b77feb20a5c2969b40969ce0c619d54faeceae73ffafb958b7e64f2c65"
+  "hash": "82d4320a02f26b9386fe7992c9a1a08a025fe0f6fcd6bb32c7ce9cfb52253a7e"
 }

--- a/.sqlx/query-8c07a34719ad5ca2f7c0acdbb90ea1a7cd2e6062c7b48d26666250d9f4539417.json
+++ b/.sqlx/query-8c07a34719ad5ca2f7c0acdbb90ea1a7cd2e6062c7b48d26666250d9f4539417.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "\n            SELECT\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                is_abone,\n                authed_token_id AS \"authed_token_id: Uuid\",\n                client_info AS \"client_info: Json<ClientInfo>\"\n            FROM\n                responses\n            WHERE\n                thread_id = ?\n            ORDER BY res_order, id\n            ",
+  "query": "\n            SELECT\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                is_abone,\n                0 AS \"is_abone_keep_id: i8\",\n                authed_token_id AS \"authed_token_id: Uuid\",\n                client_info AS \"client_info: Json<ClientInfo>\"\n            FROM\n                archived_responses\n            WHERE\n                thread_id = ?\n            ORDER BY res_order, id\n            ",
   "describe": {
     "columns": [
       {
@@ -35,7 +35,7 @@
         "name": "created_at",
         "type_info": {
           "type": "Datetime",
-          "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
+          "flags": "NOT_NULL | PRIMARY_KEY | BINARY | NO_DEFAULT_VALUE",
           "max_size": 23
         }
       },
@@ -59,6 +59,15 @@
       },
       {
         "ordinal": 6,
+        "name": "is_abone_keep_id: i8",
+        "type_info": {
+          "type": "LongLong",
+          "flags": "NOT_NULL | BINARY",
+          "max_size": 2
+        }
+      },
+      {
+        "ordinal": 7,
         "name": "authed_token_id: Uuid",
         "type_info": {
           "type": "String",
@@ -67,7 +76,7 @@
         }
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "client_info: Json<ClientInfo>",
         "type_info": {
           "type": "Json",
@@ -87,8 +96,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "456440488c7ebf7a85d93ff582b40e65aac63fd98d9d5019d12a2bf250748bfd"
+  "hash": "8c07a34719ad5ca2f7c0acdbb90ea1a7cd2e6062c7b48d26666250d9f4539417"
 }

--- a/.sqlx/query-bdec3a5b5ac2f629f87f81b85fe582f69899dd8dd22d4546dad6aa1f31e63093.json
+++ b/.sqlx/query-bdec3a5b5ac2f629f87f81b85fe582f69899dd8dd22d4546dad6aa1f31e63093.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "\n            SELECT\n                id,\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                ip_addr,\n                authed_token_id,\n                board_id,\n                thread_id,\n                is_abone,\n                client_info AS \"client_info!: Json<ClientInfo>\",\n                res_order\n            FROM\n                responses\n            WHERE\n                id = ?\n            ",
+  "query": "\n            SELECT\n                id,\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                ip_addr,\n                authed_token_id,\n                board_id,\n                thread_id,\n                is_abone,\n                is_abone_keep_id,\n                client_info AS \"client_info!: Json<ClientInfo>\",\n                res_order\n            FROM\n                responses\n            WHERE\n                id = ?\n            ",
   "describe": {
     "columns": [
       {
@@ -104,6 +104,15 @@
       },
       {
         "ordinal": 11,
+        "name": "is_abone_keep_id",
+        "type_info": {
+          "type": "Tiny",
+          "flags": "NOT_NULL",
+          "max_size": 1
+        }
+      },
+      {
+        "ordinal": 12,
         "name": "client_info!: Json<ClientInfo>",
         "type_info": {
           "type": "Json",
@@ -112,7 +121,7 @@
         }
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "res_order",
         "type_info": {
           "type": "Long",
@@ -137,8 +146,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "28336cbf8b782bdf6eb00430e8dc7de3540e4c3fd9859192a8bcda1558fd0f9c"
+  "hash": "bdec3a5b5ac2f629f87f81b85fe582f69899dd8dd22d4546dad6aa1f31e63093"
 }

--- a/.sqlx/query-c8780718526298ff2ab02d6889ff332a2c8073c78fdf15eb407c0c32f48622f5.json
+++ b/.sqlx/query-c8780718526298ff2ab02d6889ff332a2c8073c78fdf15eb407c0c32f48622f5.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "\n            SELECT\n                id,\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                ip_addr,\n                authed_token_id,\n                board_id,\n                thread_id,\n                is_abone,\n                client_info AS \"client_info!: Json<ClientInfo>\",\n                res_order\n            FROM\n                responses\n            WHERE\n                thread_id = (\n                    SELECT\n                        id\n                    FROM\n                        threads\n                    WHERE\n                        board_id = (\n                        SELECT\n                            id\n                        FROM\n                            boards\n                        WHERE\n                            board_key = ?\n                        )\n                    AND\n                        thread_number = ?\n                )\n            ORDER BY\n                res_order ASC, id ASC\n            ",
+  "query": "\n            SELECT\n                id,\n                author_name,\n                mail,\n                body,\n                created_at,\n                author_id,\n                ip_addr,\n                authed_token_id,\n                board_id,\n                thread_id,\n                is_abone,\n                is_abone_keep_id,\n                client_info AS \"client_info!: Json<ClientInfo>\",\n                res_order\n            FROM\n                responses\n            WHERE\n                thread_id = (\n                    SELECT\n                        id\n                    FROM\n                        threads\n                    WHERE\n                        board_id = (\n                        SELECT\n                            id\n                        FROM\n                            boards\n                        WHERE\n                            board_key = ?\n                        )\n                    AND\n                        thread_number = ?\n                )\n            ORDER BY\n                res_order ASC, id ASC\n            ",
   "describe": {
     "columns": [
       {
@@ -104,6 +104,15 @@
       },
       {
         "ordinal": 11,
+        "name": "is_abone_keep_id",
+        "type_info": {
+          "type": "Tiny",
+          "flags": "NOT_NULL",
+          "max_size": 1
+        }
+      },
+      {
+        "ordinal": 12,
         "name": "client_info!: Json<ClientInfo>",
         "type_info": {
           "type": "Json",
@@ -112,7 +121,7 @@
         }
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "res_order",
         "type_info": {
           "type": "Long",
@@ -137,8 +146,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "e84889e6b37e6f6aeb58a19e50579c52bab45779ac6bc14b1f310c1324b31095"
+  "hash": "c8780718526298ff2ab02d6889ff332a2c8073c78fdf15eb407c0c32f48622f5"
 }

--- a/eddist-admin/client/app/components/DatArchiveResponseList.tsx
+++ b/eddist-admin/client/app/components/DatArchiveResponseList.tsx
@@ -8,7 +8,7 @@ interface Props {
   adminResponses: components["schemas"]["ArchivedAdminRes"][];
   selectedResponsesOrder: number[];
   setSelectedResponsesOrder: React.Dispatch<React.SetStateAction<number[]>>;
-  onClieckAbon: (resOrder: number) => void;
+  onClieckAbon: (resOrder: number, keepId: boolean) => void;
   onClickDeleteAuthedToken: (authedToken: string) => void;
   onClickDeleteAuthedTokensAssociatedWithIp: (authedToken: string) => void;
   onClickEditResponse: (resOrder: number) => void;
@@ -71,7 +71,8 @@ const DatArchiveResponseList = ({
               inline
             >
               <DropdownItem onClick={() => onClickEditResponse(idx)}>Edit</DropdownItem>
-              <DropdownItem onClick={() => onClieckAbon(idx)}>Abon</DropdownItem>
+              <DropdownItem onClick={() => onClieckAbon(idx, false)}>Abon</DropdownItem>
+              <DropdownItem onClick={() => onClieckAbon(idx, true)}>Abon, keep ID</DropdownItem>
               <DropdownItem onClick={() => onClickDeleteAuthedToken(response.authed_token_id)}>
                 Delete Authed Token
               </DropdownItem>

--- a/eddist-admin/client/app/components/DatArchiveResponseList.tsx
+++ b/eddist-admin/client/app/components/DatArchiveResponseList.tsx
@@ -8,7 +8,7 @@ interface Props {
   adminResponses: components["schemas"]["ArchivedAdminRes"][];
   selectedResponsesOrder: number[];
   setSelectedResponsesOrder: React.Dispatch<React.SetStateAction<number[]>>;
-  onClieckAbon: (resOrder: number, keepId: boolean) => void;
+  onClickAbon: (resOrder: number, keepId: boolean) => void;
   onClickDeleteAuthedToken: (authedToken: string) => void;
   onClickDeleteAuthedTokensAssociatedWithIp: (authedToken: string) => void;
   onClickEditResponse: (resOrder: number) => void;
@@ -19,7 +19,7 @@ const DatArchiveResponseList = ({
   adminResponses,
   selectedResponsesOrder,
   setSelectedResponsesOrder,
-  onClieckAbon,
+  onClickAbon,
   onClickDeleteAuthedToken,
   onClickDeleteAuthedTokensAssociatedWithIp,
   onClickEditResponse,
@@ -71,8 +71,8 @@ const DatArchiveResponseList = ({
               inline
             >
               <DropdownItem onClick={() => onClickEditResponse(idx)}>Edit</DropdownItem>
-              <DropdownItem onClick={() => onClieckAbon(idx, false)}>Abon</DropdownItem>
-              <DropdownItem onClick={() => onClieckAbon(idx, true)}>Abon, keep ID</DropdownItem>
+              <DropdownItem onClick={() => onClickAbon(idx, false)}>Abon</DropdownItem>
+              <DropdownItem onClick={() => onClickAbon(idx, true)}>Abon, keep ID</DropdownItem>
               <DropdownItem onClick={() => onClickDeleteAuthedToken(response.authed_token_id)}>
                 Delete Authed Token
               </DropdownItem>

--- a/eddist-admin/client/app/components/ResponseList.tsx
+++ b/eddist-admin/client/app/components/ResponseList.tsx
@@ -84,22 +84,22 @@ const ResponseList = ({
             inline
           >
             {onClickAbon && (
-              <DropdownItem
-                onClick={() => {
-                  onClickAbon(response.id, false);
-                }}
-              >
-                Delete Response (Abon)
-              </DropdownItem>
-            )}
-            {onClickAbon && (
-              <DropdownItem
-                onClick={() => {
-                  onClickAbon(response.id, true);
-                }}
-              >
-                Delete Response, keep ID (Abon)
-              </DropdownItem>
+              <>
+                <DropdownItem
+                  onClick={() => {
+                    onClickAbon(response.id, false);
+                  }}
+                >
+                  Delete Response (Abon)
+                </DropdownItem>
+                <DropdownItem
+                  onClick={() => {
+                    onClickAbon(response.id, true);
+                  }}
+                >
+                  Delete Response, keep ID (Abon)
+                </DropdownItem>
+              </>
             )}
             <DropdownItem
               disabled={response.authed_token_id == null}

--- a/eddist-admin/client/app/components/ResponseList.tsx
+++ b/eddist-admin/client/app/components/ResponseList.tsx
@@ -8,7 +8,7 @@ interface Props {
   responses: Res[];
   selectedResponses?: ResInput[];
   setSelectedResponses?: React.Dispatch<React.SetStateAction<ResInput[]>>;
-  onClickAbon?: (responseId: string) => void;
+  onClickAbon?: (responseId: string, keepId: boolean) => void;
   onClickDeleteAuthedToken: (authedToken: string) => void;
   onClickDeleteAuthedTokensAssociatedWithIp: (authedToken: string) => void;
   onClickEditResponse?: (response: ResInput) => void;
@@ -86,10 +86,19 @@ const ResponseList = ({
             {onClickAbon && (
               <DropdownItem
                 onClick={() => {
-                  onClickAbon(response.id);
+                  onClickAbon(response.id, false);
                 }}
               >
                 Delete Response (Abon)
+              </DropdownItem>
+            )}
+            {onClickAbon && (
+              <DropdownItem
+                onClick={() => {
+                  onClickAbon(response.id, true);
+                }}
+              >
+                Delete Response, keep ID (Abon)
               </DropdownItem>
             )}
             <DropdownItem

--- a/eddist-admin/client/app/openapi/schema.d.ts
+++ b/eddist-admin/client/app/openapi/schema.d.ts
@@ -883,6 +883,7 @@ export interface components {
             id: string;
             ip_addr: string;
             is_abone: boolean;
+            is_abone_keep_id: boolean;
             mail?: string | null;
             /** Format: int32 */
             res_order: number;
@@ -1001,6 +1002,11 @@ export interface components {
             author_name?: string | null;
             body?: string | null;
             is_abone?: boolean | null;
+            /**
+             * @description Only meaningful when `is_abone` is (or already is) true: keeps the poster's author_id
+             *     visible on the abone'd line instead of blanking it out too.
+             */
+            is_abone_keep_id?: boolean | null;
             mail?: string | null;
         };
         UpdateRestrictionRuleRequest: {
@@ -1512,7 +1518,10 @@ export interface operations {
     };
     delete_archived_res: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Keep the poster's author_id visible on the abone'd line instead of blanking it out too. */
+                keep_id?: boolean | null;
+            };
             header?: never;
             path: {
                 /** @description Board ID */

--- a/eddist-admin/client/app/routes/dashboard.boards_.$boardKey_.archives.$threadId_.dat.tsx
+++ b/eddist-admin/client/app/routes/dashboard.boards_.$boardKey_.archives.$threadId_.dat.tsx
@@ -248,7 +248,7 @@ const Page = () => {
               res_order: idx,
             });
           }}
-          onClieckAbon={(idx, keepId) => {
+          onClickAbon={(idx, keepId) => {
             deleteDatResponseMutation.mutate({
               params: {
                 path: {

--- a/eddist-admin/client/app/routes/dashboard.boards_.$boardKey_.archives.$threadId_.dat.tsx
+++ b/eddist-admin/client/app/routes/dashboard.boards_.$boardKey_.archives.$threadId_.dat.tsx
@@ -248,13 +248,16 @@ const Page = () => {
               res_order: idx,
             });
           }}
-          onClieckAbon={(idx) => {
+          onClieckAbon={(idx, keepId) => {
             deleteDatResponseMutation.mutate({
               params: {
                 path: {
                   board_key: params.boardKey ?? "",
                   thread_number: Number(params.threadId),
                   res_order: idx,
+                },
+                query: {
+                  keep_id: keepId,
                 },
               },
             });

--- a/eddist-admin/client/app/routes/dashboard.boards_.$boardKey_.threads.$threadId.tsx
+++ b/eddist-admin/client/app/routes/dashboard.boards_.$boardKey_.threads.$threadId.tsx
@@ -10,6 +10,7 @@ export interface ResInput {
   author_name?: string;
   body?: string;
   is_abone?: boolean;
+  is_abone_keep_id?: boolean;
   mail?: string;
   id: string;
 }
@@ -24,6 +25,7 @@ export interface Res {
   ip_addr: string;
   authed_token_id: string;
   is_abone: boolean;
+  is_abone_keep_id: boolean;
   client_info: ClientInfo;
 }
 
@@ -89,6 +91,7 @@ const Page = () => {
           author_name: res.author_name,
           body: res.body,
           is_abone: res.is_abone,
+          is_abone_keep_id: res.is_abone_keep_id,
           mail: res.mail,
         },
       });
@@ -198,13 +201,13 @@ const Page = () => {
           </span>
         </Breadcrumb>
         <ResponseList
-          onClickAbon={async (responseId) => {
+          onClickAbon={async (responseId, keepId) => {
             const res = responses?.find((res) => res.id === responseId);
-            console.log(res?.id, responseId);
             if (res) {
               const abonedRes = {
                 id: res.id,
                 is_abone: true,
+                is_abone_keep_id: keepId,
               } satisfies ResInput;
               await updateResp(abonedRes, res.id);
             }

--- a/eddist-admin/openapi.json
+++ b/eddist-admin/openapi.json
@@ -803,6 +803,18 @@
               "format": "int64",
               "minimum": 0
             }
+          },
+          {
+            "name": "keep_id",
+            "in": "query",
+            "description": "Keep the poster's author_id visible on the abone'd line instead of blanking it out too.",
+            "required": false,
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
           }
         ],
         "responses": {
@@ -3358,6 +3370,7 @@
           "board_id",
           "thread_id",
           "is_abone",
+          "is_abone_keep_id",
           "client_info",
           "res_order"
         ],
@@ -3397,6 +3410,9 @@
             "type": "string"
           },
           "is_abone": {
+            "type": "boolean"
+          },
+          "is_abone_keep_id": {
             "type": "boolean"
           },
           "mail": {
@@ -3861,6 +3877,13 @@
               "boolean",
               "null"
             ]
+          },
+          "is_abone_keep_id": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Only meaningful when `is_abone` is (or already is) true: keeps the poster's author_id\nvisible on the abone'd line instead of blanking it out too."
           },
           "mail": {
             "type": [

--- a/eddist-admin/src/models/response.rs
+++ b/eddist-admin/src/models/response.rs
@@ -19,6 +19,7 @@ pub struct Res {
     pub board_id: Uuid,
     pub thread_id: Uuid,
     pub is_abone: bool,
+    pub is_abone_keep_id: bool,
     pub client_info: ClientInfo,
     pub res_order: i32,
 }
@@ -75,4 +76,7 @@ pub struct UpdateResInput {
     pub mail: Option<String>,
     pub body: Option<String>,
     pub is_abone: Option<bool>,
+    /// Only meaningful when `is_abone` is (or already is) true: keeps the poster's author_id
+    /// visible on the abone'd line instead of blanking it out too.
+    pub is_abone_keep_id: Option<bool>,
 }

--- a/eddist-admin/src/repository/admin_archive_repository.rs
+++ b/eddist-admin/src/repository/admin_archive_repository.rs
@@ -264,19 +264,9 @@ fn convert_dat_file_to_res(dat_file: &str) -> ArchivedThread {
             let author_id = date_and_author_id_split.get(1).map(|s| s.to_string());
             let body = split[3];
 
-            // A real post's name/mail/body are free-form user (or, via the edit API,
-            // admin) text, so a poster could deliberately write name="あぼーん",
-            // body="あぼーん" to spoof an abone line. To tell a genuine abone apart:
-            // - id-stripped abone never has an " ID:" segment, which a real post
-            //   always has (the renderer always appends the real author_id), so
-            //   ID-absence alone is an unspoofable, server-controlled signal.
-            // - id-kept abone does carry a real ID, so that signal is unavailable.
-            //   Instead it replaces the date sub-field with a fixed "あぼーん"
-            //   sentinel. Unlike name/mail/body, the date is never derived from any
-            //   user- or admin-editable input in any rendering path (eddist-core's
-            //   renderer, used by eddist-cron to write the original archived dat,
-            //   uses the identical sentinel — see get_sjis_bytes), so it can never
-            //   collide with a genuine post's real timestamp.
+            // name/mail/body are editable text, so a post could spoof "あぼーん" there.
+            // ID-absence (id-stripped) and the date sentinel (id-kept, see
+            // get_sjis_bytes) aren't editable, so they can't be spoofed.
             let is_abone = if author_id.is_none() {
                 split[0] == "あぼーん" && body.trim() == "あぼーん"
             } else {
@@ -354,13 +344,8 @@ fn convert_reses_to_dat_file(reses: Vec<ArchivedRes>, thread_title: &str) -> Vec
                     "".to_string()
                 };
                 match res.author_id.as_deref() {
-                    // The date sub-field is replaced with a fixed "あぼーん" sentinel
-                    // (matching eddist-core's get_sjis_bytes, which eddist-cron uses to
-                    // write the original archived dat) instead of the real timestamp.
-                    // Unlike name/mail/body, date is never derived from any user- or
-                    // admin-editable input, so it can never collide with a genuine
-                    // post's real timestamp — see convert_dat_file_to_res for the
-                    // matching detection logic.
+                    // Date replaced with an "あぼーん" sentinel (matches get_sjis_bytes)
+                    // instead of the real timestamp — see convert_dat_file_to_res.
                     Some(author_id) => SJisStr::from(&format!(
                         "あぼーん<>あぼーん<>あぼーん ID:{}<> あぼーん <>{}\n",
                         author_id, title
@@ -457,12 +442,6 @@ mod tests {
 
     #[test]
     fn test_genuine_post_spoofing_abone_text_is_not_misdetected() {
-        // A real (non-deleted) post whose author deliberately set name="あぼーん"
-        // and body="あぼーん" to mimic an abone line must NOT be misdetected as
-        // abone: the real timestamp in the date sub-field is never producible via
-        // any user- or admin-editable input, so it disambiguates this from a
-        // genuine id-kept abone line (whose date sub-field is the "あぼーん"
-        // sentinel, not a real timestamp).
         let spoofing_res = ArchivedRes {
             name: "あぼーん".to_string(),
             mail: "あぼーん".to_string(),

--- a/eddist-admin/src/repository/admin_archive_repository.rs
+++ b/eddist-admin/src/repository/admin_archive_repository.rs
@@ -28,6 +28,7 @@ pub(crate) trait AdminArchiveRepository: Send + Sync {
         board_key: &str,
         thread_number: u64,
         res_order: u64,
+        keep_id: bool,
     ) -> anyhow::Result<()>;
     async fn delete_thread(&self, board_key: &str, thread_number: u64) -> anyhow::Result<()>;
 }
@@ -181,6 +182,7 @@ impl AdminArchiveRepository for AdminArchiveRepositoryImpl {
         board_key: &str,
         thread_number: u64,
         res_order: u64,
+        keep_id: bool,
     ) -> anyhow::Result<()> {
         let mut a_thread = self.get_thread(board_key, thread_number).await?;
         let resp = a_thread
@@ -192,6 +194,9 @@ impl AdminArchiveRepository for AdminArchiveRepositoryImpl {
                 thread_number
             ))?;
         resp.is_abone = true;
+        if !keep_id {
+            resp.author_id = None;
+        }
 
         let dat = convert_reses_to_dat_file(a_thread.responses, &a_thread.title);
 
@@ -255,15 +260,40 @@ fn convert_dat_file_to_res(dat_file: &str) -> ArchivedThread {
             }
 
             let date_and_author_id_split: Vec<&str> = split[2].split(" ID:").collect();
+            let date = date_and_author_id_split[0];
+            let author_id = date_and_author_id_split.get(1).map(|s| s.to_string());
+            let body = split[3];
+
+            // A real post's name/mail/body are free-form user (or, via the edit API,
+            // admin) text, so a poster could deliberately write name="あぼーん",
+            // body="あぼーん" to spoof an abone line. To tell a genuine abone apart:
+            // - id-stripped abone never has an " ID:" segment, which a real post
+            //   always has (the renderer always appends the real author_id), so
+            //   ID-absence alone is an unspoofable, server-controlled signal.
+            // - id-kept abone does carry a real ID, so that signal is unavailable.
+            //   Instead it replaces the date sub-field with a fixed "あぼーん"
+            //   sentinel. Unlike name/mail/body, the date is never derived from any
+            //   user- or admin-editable input in any rendering path (eddist-core's
+            //   renderer, used by eddist-cron to write the original archived dat,
+            //   uses the identical sentinel — see get_sjis_bytes), so it can never
+            //   collide with a genuine post's real timestamp.
+            let is_abone = if author_id.is_none() {
+                split[0] == "あぼーん" && body.trim() == "あぼーん"
+            } else {
+                date == "あぼーん"
+            };
+
             Some(ArchivedRes {
                 name: split[0].to_string(),
                 mail: split[1].to_string(),
-                date: date_and_author_id_split[0].to_string(),
-                author_id: date_and_author_id_split.get(1).map(|s| s.to_string()),
-                body: split[3].to_string(),
-                is_abone: date_and_author_id_split.get(1).is_none()
-                    && split[0] == "あぼーん"
-                    && split[3].trim() == "あぼーん",
+                date: date.to_string(),
+                author_id,
+                body: if is_abone {
+                    "あぼーん".to_string()
+                } else {
+                    body.to_string()
+                },
+                is_abone,
                 order: idx as u64,
             })
         })
@@ -318,14 +348,27 @@ fn convert_reses_to_dat_file(reses: Vec<ArchivedRes>, thread_title: &str) -> Vec
         .enumerate()
         .map(|(idx, res)| {
             if res.is_abone {
-                SJisStr::from(&format!(
-                    "あぼーん<>あぼーん<><> あぼーん<>{}\n",
-                    if idx == 0 {
-                        thread_title.to_string()
-                    } else {
-                        "".to_string()
-                    }
-                ) as &str)
+                let title = if idx == 0 {
+                    thread_title.to_string()
+                } else {
+                    "".to_string()
+                };
+                match res.author_id.as_deref() {
+                    // The date sub-field is replaced with a fixed "あぼーん" sentinel
+                    // (matching eddist-core's get_sjis_bytes, which eddist-cron uses to
+                    // write the original archived dat) instead of the real timestamp.
+                    // Unlike name/mail/body, date is never derived from any user- or
+                    // admin-editable input, so it can never collide with a genuine
+                    // post's real timestamp — see convert_dat_file_to_res for the
+                    // matching detection logic.
+                    Some(author_id) => SJisStr::from(&format!(
+                        "あぼーん<>あぼーん<>あぼーん ID:{}<> あぼーん <>{}\n",
+                        author_id, title
+                    ) as &str),
+                    None => SJisStr::from(
+                        &format!("あぼーん<>あぼーん<><> あぼーん<>{}\n", title) as &str
+                    ),
+                }
             } else {
                 SJisStr::from(&format!(
                     "{}<>{}<>{} ID:{}<>{}<>{}\n",
@@ -352,4 +395,92 @@ fn convert_reses_to_dat_file(reses: Vec<ArchivedRes>, thread_title: &str) -> Vec
         .0
         .into_owned()
         .into_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_reses() -> Vec<ArchivedRes> {
+        vec![
+            ArchivedRes {
+                name: "名無しさん".to_string(),
+                mail: "".to_string(),
+                date: "2024/01/01(月) 00:00:00.00".to_string(),
+                author_id: Some("ABC123456".to_string()),
+                body: "本文1".to_string(),
+                is_abone: false,
+                order: 0,
+            },
+            ArchivedRes {
+                name: "荒らし".to_string(),
+                mail: "".to_string(),
+                date: "2024/01/01(月) 00:01:00.00".to_string(),
+                author_id: Some("XYZ789012".to_string()),
+                body: "削除対象".to_string(),
+                is_abone: true,
+                order: 1,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_abone_strip_id_round_trip() {
+        let mut reses = sample_reses();
+        reses[1].author_id = None; // strip id (current default behavior)
+
+        let dat = convert_reses_to_dat_file(reses, "テストスレッド");
+        let dat_str = String::from_utf8(dat).unwrap();
+
+        let parsed = convert_dat_file_to_res(&dat_str);
+        let abone_res = &parsed.responses[1];
+
+        assert!(abone_res.is_abone);
+        assert_eq!(abone_res.author_id, None);
+    }
+
+    #[test]
+    fn test_abone_keep_id_round_trip() {
+        let reses = sample_reses(); // second response is abone with author_id kept
+
+        let dat = convert_reses_to_dat_file(reses, "テストスレッド");
+        let dat_str = String::from_utf8(dat).unwrap();
+
+        let parsed = convert_dat_file_to_res(&dat_str);
+        let abone_res = &parsed.responses[1];
+
+        assert!(abone_res.is_abone);
+        assert_eq!(abone_res.author_id.as_deref(), Some("XYZ789012"));
+        assert!(!abone_res.body.contains("削除対象"));
+        assert!(!abone_res.name.contains("荒らし"));
+    }
+
+    #[test]
+    fn test_genuine_post_spoofing_abone_text_is_not_misdetected() {
+        // A real (non-deleted) post whose author deliberately set name="あぼーん"
+        // and body="あぼーん" to mimic an abone line must NOT be misdetected as
+        // abone: the real timestamp in the date sub-field is never producible via
+        // any user- or admin-editable input, so it disambiguates this from a
+        // genuine id-kept abone line (whose date sub-field is the "あぼーん"
+        // sentinel, not a real timestamp).
+        let spoofing_res = ArchivedRes {
+            name: "あぼーん".to_string(),
+            mail: "あぼーん".to_string(),
+            date: "2024/01/01(月) 00:00:00.00".to_string(),
+            author_id: Some("SPOOF12345".to_string()),
+            body: "あぼーん".to_string(),
+            is_abone: false,
+            order: 0,
+        };
+
+        let dat = convert_reses_to_dat_file(vec![spoofing_res], "テストスレッド");
+        let dat_str = String::from_utf8(dat).unwrap();
+
+        let parsed = convert_dat_file_to_res(&dat_str);
+        let res = &parsed.responses[0];
+
+        assert!(!res.is_abone);
+        assert_eq!(res.author_id.as_deref(), Some("SPOOF12345"));
+        assert_eq!(res.body, "あぼーん");
+    }
 }

--- a/eddist-admin/src/repository/admin_archive_repository.rs
+++ b/eddist-admin/src/repository/admin_archive_repository.rs
@@ -351,7 +351,7 @@ fn convert_reses_to_dat_file(reses: Vec<ArchivedRes>, thread_title: &str) -> Vec
                         author_id, title
                     ) as &str),
                     None => SJisStr::from(
-                        &format!("あぼーん<>あぼーん<><> あぼーん<>{}\n", title) as &str
+                        &format!("あぼーん<>あぼーん<><> あぼーん <>{}\n", title) as &str,
                     ),
                 }
             } else {
@@ -438,6 +438,65 @@ mod tests {
         assert_eq!(abone_res.author_id.as_deref(), Some("XYZ789012"));
         assert!(!abone_res.body.contains("削除対象"));
         assert!(!abone_res.name.contains("荒らし"));
+    }
+
+    /// The dat rewritten here has to be byte-identical to what eddist-cron writes through
+    /// eddist-core, otherwise an admin edit silently reformats every abone'd line in the file.
+    fn core_abone_line(author_id: Option<&str>, thread_title: &str) -> String {
+        use chrono::{TimeZone, Utc};
+        use eddist_core::domain::res::ResView;
+
+        ResView {
+            author_name: "荒らし".to_string(),
+            mail: "".to_string(),
+            body: "削除対象".to_string(),
+            created_at: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+            author_id: author_id.unwrap_or_default().to_string(),
+            is_abone: true,
+            is_abone_keep_id: author_id.is_some(),
+        }
+        .get_sjis_bytes("名無しさん", Some(thread_title))
+        .to_string()
+    }
+
+    fn admin_abone_line(author_id: Option<&str>, thread_title: &str) -> String {
+        let res = ArchivedRes {
+            name: "荒らし".to_string(),
+            mail: "".to_string(),
+            date: "2024/01/01(月) 00:00:00.00".to_string(),
+            author_id: author_id.map(|s| s.to_string()),
+            body: "削除対象".to_string(),
+            is_abone: true,
+            order: 0,
+        };
+
+        String::from_utf8(convert_reses_to_dat_file(vec![res], thread_title)).unwrap()
+    }
+
+    /// Dat files already in S3 were written with no space before the closing `<>`.
+    #[test]
+    fn test_legacy_strip_id_abone_line_is_still_detected() {
+        let parsed = convert_dat_file_to_res("あぼーん<>あぼーん<><> あぼーん<>テストスレッド\n");
+        let res = &parsed.responses[0];
+
+        assert!(res.is_abone);
+        assert_eq!(res.author_id, None);
+    }
+
+    #[test]
+    fn test_abone_strip_id_line_matches_eddist_core() {
+        assert_eq!(
+            admin_abone_line(None, "テストスレッド"),
+            core_abone_line(None, "テストスレッド")
+        );
+    }
+
+    #[test]
+    fn test_abone_keep_id_line_matches_eddist_core() {
+        assert_eq!(
+            admin_abone_line(Some("XYZ789012"), "テストスレッド"),
+            core_abone_line(Some("XYZ789012"), "テストスレッド")
+        );
     }
 
     #[test]

--- a/eddist-admin/src/repository/admin_bbs_repository.rs
+++ b/eddist-admin/src/repository/admin_bbs_repository.rs
@@ -61,6 +61,7 @@ pub struct SelectionRes {
     pub board_id: Vec<u8>,
     pub thread_id: Vec<u8>,
     pub is_abone: i8,
+    pub is_abone_keep_id: i8,
     pub res_order: i32,
     pub client_info: Json<ClientInfo>,
 }

--- a/eddist-admin/src/repository/admin_response_repository.rs
+++ b/eddist-admin/src/repository/admin_response_repository.rs
@@ -31,6 +31,7 @@ pub trait AdminResponseRepository: Send + Sync {
         mail: Option<String>,
         body: Option<String>,
         is_abone: Option<bool>,
+        is_abone_keep_id: Option<bool>,
     ) -> anyhow::Result<Res>;
 }
 
@@ -56,6 +57,7 @@ fn selection_res_to_res(res: SelectionRes) -> Res {
         board_id: Uuid::from_slice(&res.board_id).unwrap(),
         thread_id: Uuid::from_slice(&res.thread_id).unwrap(),
         is_abone: res.is_abone != 0,
+        is_abone_keep_id: res.is_abone_keep_id != 0,
         client_info: res.client_info.0.into(),
         res_order: res.res_order,
     }
@@ -85,6 +87,7 @@ impl AdminResponseRepository for AdminResponseRepositoryImpl {
                 board_id,
                 thread_id,
                 is_abone,
+                is_abone_keep_id,
                 client_info AS "client_info!: Json<ClientInfo>",
                 res_order
             FROM
@@ -143,6 +146,7 @@ impl AdminResponseRepository for AdminResponseRepositoryImpl {
                 board_id,
                 thread_id,
                 is_abone,
+                0 AS "is_abone_keep_id: i8",
                 client_info AS "client_info!: Json<ClientInfo>",
                 res_order
             FROM
@@ -200,6 +204,7 @@ impl AdminResponseRepository for AdminResponseRepositoryImpl {
                 board_id,
                 thread_id,
                 is_abone,
+                is_abone_keep_id,
                 client_info AS "client_info!: Json<ClientInfo>",
                 res_order
             FROM
@@ -256,6 +261,7 @@ impl AdminResponseRepository for AdminResponseRepositoryImpl {
         mail: Option<String>,
         body: Option<String>,
         is_abone: Option<bool>,
+        is_abone_keep_id: Option<bool>,
     ) -> anyhow::Result<Res> {
         let pool = &self.0;
 
@@ -277,6 +283,9 @@ impl AdminResponseRepository for AdminResponseRepositoryImpl {
         if is_abone.is_some() {
             sets.push("is_abone = ?");
         }
+        if is_abone_keep_id.is_some() {
+            sets.push("is_abone_keep_id = ?");
+        }
 
         let query = format!(
             r#"
@@ -297,6 +306,9 @@ impl AdminResponseRepository for AdminResponseRepositoryImpl {
         if let Some(is_abone) = is_abone {
             query = query.bind(is_abone);
         }
+        if let Some(is_abone_keep_id) = is_abone_keep_id {
+            query = query.bind(is_abone_keep_id);
+        }
         let query = query.bind(id.as_bytes().to_vec());
 
         query.execute(pool).await?;
@@ -316,6 +328,7 @@ impl AdminResponseRepository for AdminResponseRepositoryImpl {
                 board_id,
                 thread_id,
                 is_abone,
+                is_abone_keep_id,
                 client_info AS "client_info!: Json<ClientInfo>",
                 res_order
             FROM

--- a/eddist-admin/src/repository/admin_response_repository.rs
+++ b/eddist-admin/src/repository/admin_response_repository.rs
@@ -131,6 +131,9 @@ impl AdminResponseRepository for AdminResponseRepositoryImpl {
     ) -> anyhow::Result<Vec<Res>> {
         let pool = &self.0;
 
+        // `archived_responses` has no `is_abone_keep_id` column, so it is selected as a constant
+        // 0 here. Whether an archived response kept its author_id is encoded in the dat text in
+        // S3 (see admin_archive_repository), which is the source of truth for archived threads.
         let query = query_as!(
             SelectionRes,
             r#"

--- a/eddist-admin/src/routes/archives.rs
+++ b/eddist-admin/src/routes/archives.rs
@@ -217,6 +217,12 @@ pub async fn update_archived_res(
     Ok(StatusCode::OK)
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, IntoParams)]
+pub struct DeleteArchivedResQuery {
+    /// Keep the poster's author_id visible on the abone'd line instead of blanking it out too.
+    keep_id: Option<bool>,
+}
+
 #[utoipa::path(
     delete,
     path = "/boards/{board_key}/dat-archives/{thread_number}/responses/{res_order}/",
@@ -227,17 +233,25 @@ pub async fn update_archived_res(
         ("board_key" = String, Path, description = "Board ID"),
         ("thread_number" = u64, Path, description = "Thread ID"),
         ("res_order" = u64, Path, description = "Response order"),
+        DeleteArchivedResQuery
     ),
 )]
 pub async fn delete_archived_res(
     State(state): State<AppState>,
     identity: AdminIdentity,
     Path((board_key, thread_number, res_order)): Path<(String, u64, u64)>,
+    Query(query): Query<DeleteArchivedResQuery>,
 ) -> Result<StatusCode, ApiError> {
     state
         .services
         .archive
-        .delete_archived_res(&identity, &board_key, thread_number, res_order)
+        .delete_archived_res(
+            &identity,
+            &board_key,
+            thread_number,
+            res_order,
+            query.keep_id.unwrap_or(false),
+        )
         .await?;
     Ok(StatusCode::OK)
 }

--- a/eddist-admin/src/services/archive_service.rs
+++ b/eddist-admin/src/services/archive_service.rs
@@ -57,6 +57,7 @@ pub trait AdminArchiveService: Send + Sync {
         board_key: &str,
         thread_number: u64,
         res_order: u64,
+        keep_id: bool,
     ) -> anyhow::Result<()>;
     async fn delete_archived_thread(
         &self,
@@ -159,9 +160,10 @@ impl AdminArchiveService for ArchiveServiceImpl {
         board_key: &str,
         thread_number: u64,
         res_order: u64,
+        keep_id: bool,
     ) -> anyhow::Result<()> {
         self.archive_repo
-            .delete_response(board_key, thread_number, res_order)
+            .delete_response(board_key, thread_number, res_order, keep_id)
             .await
     }
 

--- a/eddist-admin/src/services/thread_service.rs
+++ b/eddist-admin/src/services/thread_service.rs
@@ -95,6 +95,7 @@ impl ThreadService for ThreadServiceImpl {
                 input.mail.clone(),
                 input.body.clone(),
                 input.is_abone,
+                input.is_abone_keep_id,
             )
             .await?;
 
@@ -105,6 +106,7 @@ impl ThreadService for ThreadServiceImpl {
             .mail
             .unwrap_or_else(|| res.mail.clone().unwrap_or_default());
         let is_abone = input.is_abone.unwrap_or(res.is_abone);
+        let is_abone_keep_id = input.is_abone_keep_id.unwrap_or(res.is_abone_keep_id);
         let body = input.body.unwrap_or_else(|| res.body.clone());
         let res_order = res.res_order;
 
@@ -115,6 +117,7 @@ impl ThreadService for ThreadServiceImpl {
             created_at: res.created_at,
             author_id: res.author_id,
             is_abone,
+            is_abone_keep_id,
         };
         let title_for_view = if res_order == 1 {
             thread_title.as_deref()

--- a/eddist-core/src/domain/res.rs
+++ b/eddist-core/src/domain/res.rs
@@ -13,6 +13,7 @@ pub struct ResView {
     pub created_at: DateTime<Utc>,
     pub author_id: String,
     pub is_abone: bool,
+    pub is_abone_keep_id: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -23,6 +24,7 @@ pub struct ResViewRef<'a> {
     pub created_at: DateTime<Utc>,
     pub author_id: &'a str,
     pub is_abone: bool,
+    pub is_abone_keep_id: bool,
 }
 
 pub fn get_sjis_bytes(
@@ -32,13 +34,29 @@ pub fn get_sjis_bytes(
 ) -> SJisStr {
     let mail = if res_view.mail == "sage" { "sage" } else { "" };
     if res_view.is_abone {
-        SJisStr::from(
-            format!(
-                "あぼーん<>あぼーん<><> あぼーん <>{}\n",
-                thread_title.unwrap_or_default()
+        if res_view.is_abone_keep_id {
+            // The date sub-field is replaced with a fixed "あぼーん" sentinel instead of
+            // the real timestamp. Unlike name/mail/body, the date is never derived from
+            // any user- or admin-editable input in any rendering path, so this sentinel
+            // can never collide with a genuine post — see convert_dat_file_to_res in
+            // eddist-admin for the matching detection logic on the archived-dat side.
+            SJisStr::from(
+                format!(
+                    "あぼーん<>あぼーん<>あぼーん ID:{}<> あぼーん <>{}\n",
+                    &res_view.author_id,
+                    thread_title.unwrap_or_default()
+                )
+                .as_str(),
             )
-            .as_str(),
-        )
+        } else {
+            SJisStr::from(
+                format!(
+                    "あぼーん<>あぼーん<><> あぼーん <>{}\n",
+                    thread_title.unwrap_or_default()
+                )
+                .as_str(),
+            )
+        }
     } else {
         SJisStr::from(
             format!(
@@ -98,6 +116,7 @@ impl ResView {
                 created_at: self.created_at,
                 author_id: &self.author_id,
                 is_abone: self.is_abone,
+                is_abone_keep_id: self.is_abone_keep_id,
             },
             default_name,
             thread_title,
@@ -145,6 +164,7 @@ mod tests {
             created_at: Utc.with_ymd_and_hms(2023, 1, 1, 12, 0, 0).unwrap(),
             author_id: "ABC123",
             is_abone: false,
+            is_abone_keep_id: false,
         };
 
         let result = get_sjis_bytes(res_view, "名無しさん", Some("テストスレッド"));
@@ -165,6 +185,7 @@ mod tests {
             created_at: Utc.with_ymd_and_hms(2023, 1, 1, 12, 0, 0).unwrap(),
             author_id: "DEF456",
             is_abone: false,
+            is_abone_keep_id: false,
         };
 
         let result = get_sjis_bytes(res_view, "名無しさん", None);
@@ -183,6 +204,7 @@ mod tests {
             created_at: Utc.with_ymd_and_hms(2023, 1, 1, 12, 0, 0).unwrap(),
             author_id: "XYZ789",
             is_abone: true,
+            is_abone_keep_id: false,
         };
 
         let result = get_sjis_bytes(res_view, "名無しさん", Some("テストスレッド"));
@@ -191,5 +213,30 @@ mod tests {
         assert!(output.contains("あぼーん"));
         assert!(!output.contains("荒らし"));
         assert!(!output.contains("削除対象"));
+        assert!(!output.contains("ID:XYZ789"));
+    }
+
+    #[test]
+    fn test_get_sjis_bytes_abone_keep_id() {
+        let res_view = ResViewRef {
+            author_name: "荒らし",
+            mail: "",
+            body: "削除対象",
+            created_at: Utc.with_ymd_and_hms(2023, 1, 1, 12, 0, 0).unwrap(),
+            author_id: "XYZ789",
+            is_abone: true,
+            is_abone_keep_id: true,
+        };
+
+        let result = get_sjis_bytes(res_view, "名無しさん", Some("テストスレッド"));
+        let output = result.to_string();
+
+        assert!(output.contains("あぼーん"));
+        assert!(!output.contains("荒らし"));
+        assert!(!output.contains("削除対象"));
+        assert!(output.contains("ID:XYZ789"));
+        // date sub-field is replaced with the "あぼーん" sentinel, not the real timestamp
+        assert!(output.contains("あぼーん ID:XYZ789"));
+        assert!(!output.contains("2023"));
     }
 }

--- a/eddist-core/src/domain/res.rs
+++ b/eddist-core/src/domain/res.rs
@@ -35,15 +35,12 @@ pub fn get_sjis_bytes(
     let mail = if res_view.mail == "sage" { "sage" } else { "" };
     if res_view.is_abone {
         if res_view.is_abone_keep_id {
-            // The date sub-field is replaced with a fixed "あぼーん" sentinel instead of
-            // the real timestamp. Unlike name/mail/body, the date is never derived from
-            // any user- or admin-editable input in any rendering path, so this sentinel
-            // can never collide with a genuine post — see convert_dat_file_to_res in
-            // eddist-admin for the matching detection logic on the archived-dat side.
+            // Date replaced with an "あぼーん" sentinel instead of the real timestamp —
+            // unlike name/mail/body it's never user-editable, so it can't be spoofed.
             SJisStr::from(
                 format!(
                     "あぼーん<>あぼーん<>あぼーん ID:{}<> あぼーん <>{}\n",
-                    &res_view.author_id,
+                    res_view.author_id,
                     thread_title.unwrap_or_default()
                 )
                 .as_str(),

--- a/eddist-cron/src/repository.rs
+++ b/eddist-cron/src/repository.rs
@@ -240,6 +240,9 @@ impl Repository {
     ) -> anyhow::Result<Vec<(ResView, ClientInfo, Uuid)>> {
         let thread_id = Vec::<u8>::from(thread_id);
 
+        // `archived_responses` has no `is_abone_keep_id` column, so it is selected as a constant 0
+        // here. This only feeds `backfill-convert`, which regenerates a dat solely when the S3
+        // object is missing, so an already-published keep-id line is never overwritten by it.
         let responses = sqlx::query_as!(
             Res,
             r#"

--- a/eddist-cron/src/repository.rs
+++ b/eddist-cron/src/repository.rs
@@ -200,6 +200,7 @@ impl Repository {
                 created_at,
                 author_id,
                 is_abone,
+                is_abone_keep_id,
                 authed_token_id AS "authed_token_id: Uuid",
                 client_info AS "client_info: Json<ClientInfo>"
             FROM
@@ -224,6 +225,7 @@ impl Repository {
                         created_at: Utc.from_utc_datetime(&r.created_at),
                         author_id: r.author_id,
                         is_abone: r.is_abone == 1,
+                        is_abone_keep_id: r.is_abone_keep_id == 1,
                     },
                     r.client_info.0,
                     r.authed_token_id,
@@ -248,6 +250,7 @@ impl Repository {
                 created_at,
                 author_id,
                 is_abone,
+                0 AS "is_abone_keep_id: i8",
                 authed_token_id AS "authed_token_id: Uuid",
                 client_info AS "client_info: Json<ClientInfo>"
             FROM
@@ -272,6 +275,7 @@ impl Repository {
                         created_at: Utc.from_utc_datetime(&r.created_at),
                         author_id: r.author_id,
                         is_abone: r.is_abone == 1,
+                        is_abone_keep_id: r.is_abone_keep_id == 1,
                     },
                     r.client_info.0,
                     r.authed_token_id,
@@ -386,6 +390,7 @@ struct Res {
     created_at: chrono::NaiveDateTime,
     author_id: String,
     is_abone: i8,
+    is_abone_keep_id: i8,
     authed_token_id: Uuid,
     client_info: Json<ClientInfo>,
 }

--- a/eddist-server/client-v2/app/api-client/thread.ts
+++ b/eddist-server/client-v2/app/api-client/thread.ts
@@ -87,11 +87,8 @@ const convertThreadTextToResponseList = (text: string) => {
 
   const responses: Response[] = lines.map((line, idx) => {
     // あぼーん, author_id kept: あぼーん<>あぼーん<>あぼーん ID:{authorId}<> あぼーん <>{title}
-    // The date sub-field is a fixed "あぼーん" sentinel, not the real timestamp — see
-    // eddist-core's get_sjis_bytes / eddist-admin's convert_reses_to_dat_file for why:
-    // unlike name/mail/body (user- or admin-editable free text), date is never derived
-    // from any editable input, so it can't collide with a genuine post that spoofs
-    // name="あぼーん"/body="あぼーん" to mimic a deleted line.
+    // Date is a fixed "あぼーん" sentinel, not the real timestamp — unlike name/mail/body
+    // it's never user-editable, so it can't be spoofed by a real post (see get_sjis_bytes).
     const aboneKeepIdRegex = /^あぼーん<>あぼーん<>あぼーん ID:(.*)<> あぼーん <>(.*)$/;
     const aboneKeepIdMatch = line.match(aboneKeepIdRegex);
     if (aboneKeepIdMatch != null) {

--- a/eddist-server/client-v2/app/api-client/thread.ts
+++ b/eddist-server/client-v2/app/api-client/thread.ts
@@ -77,6 +77,17 @@ export const fetchThread = async (
   return result;
 };
 
+// name<>mail<>{date} ID:{authorId}<>{body}<>{title}
+const LINE_REGEX = /^(.*)<>(.*)<>(.*) ID:(.*)<>(.*)<>(.*)$/;
+// あぼーん, author_id kept: あぼーん<>あぼーん<>あぼーん ID:{authorId}<> あぼーん <>{title}
+// Date is a fixed "あぼーん" sentinel, not the real timestamp — unlike name/mail/body
+// it's never user-editable, so it can't be spoofed by a real post (see get_sjis_bytes).
+const ABONE_KEEP_ID_REGEX = /^あぼーん<>あぼーん<>あぼーん ID:(.*)<> あぼーん <>(.*)$/;
+// あぼーん, author_id stripped: あぼーん<>あぼーん<><> あぼーん <>{title}
+const ABONE_STRIP_ID_REGEX = /^(.*)<>(.*)<><> あぼーん <>(.*)$/;
+// 1001 stopper line: "1001<><>Over 1000 Thread<>{body}<>"
+const STOPPER_REGEX = /^(.*)<>(.*)<>Over 1000 Thread<>(.*)<>(.*)$/;
+
 const convertThreadTextToResponseList = (text: string) => {
   const lines = text.split("\n").filter((x) => x !== "");
   let threadTitle = "";
@@ -86,11 +97,7 @@ const convertThreadTextToResponseList = (text: string) => {
   const referredMap = new Map<number, number[]>();
 
   const responses: Response[] = lines.map((line, idx) => {
-    // あぼーん, author_id kept: あぼーん<>あぼーん<>あぼーん ID:{authorId}<> あぼーん <>{title}
-    // Date is a fixed "あぼーん" sentinel, not the real timestamp — unlike name/mail/body
-    // it's never user-editable, so it can't be spoofed by a real post (see get_sjis_bytes).
-    const aboneKeepIdRegex = /^あぼーん<>あぼーん<>あぼーん ID:(.*)<> あぼーん <>(.*)$/;
-    const aboneKeepIdMatch = line.match(aboneKeepIdRegex);
+    const aboneKeepIdMatch = line.match(ABONE_KEEP_ID_REGEX);
     if (aboneKeepIdMatch != null) {
       const authorId = aboneKeepIdMatch[1];
       if (idx === 0) {
@@ -122,16 +129,11 @@ const convertThreadTextToResponseList = (text: string) => {
       return response;
     }
 
-    const lineRegex = /^(.*)<>(.*)<>(.*) ID:(.*)<>(.*)<>(.*)$/;
-    const match = line.match(lineRegex);
+    const match = line.match(LINE_REGEX);
     if (match == null) {
-      // あぼーん, author_id stripped: あぼーん<>あぼーん<><> あぼーん <>{title}
-      const aboneStripRegex = /^(.*)<>(.*)<><> あぼーん <>(.*)$/;
-      const aboneStripMatch = line.match(aboneStripRegex);
+      const aboneStripMatch = line.match(ABONE_STRIP_ID_REGEX);
       if (aboneStripMatch == null) {
-        // 1001 stopper line: "1001<><>Over 1000 Thread<>{body}<>"
-        const stopperRegex = /^(.*)<>(.*)<>Over 1000 Thread<>(.*)<>(.*)$/;
-        const stopperMatch = line.match(stopperRegex);
+        const stopperMatch = line.match(STOPPER_REGEX);
         if (stopperMatch == null) {
           throw new Error(`Invalid response line: ${line}`);
         }

--- a/eddist-server/client-v2/app/api-client/thread.ts
+++ b/eddist-server/client-v2/app/api-client/thread.ts
@@ -86,13 +86,52 @@ const convertThreadTextToResponseList = (text: string) => {
   const referredMap = new Map<number, number[]>();
 
   const responses: Response[] = lines.map((line, idx) => {
+    // あぼーん, author_id kept: あぼーん<>あぼーん<>あぼーん ID:{authorId}<> あぼーん <>{title}
+    // The date sub-field is a fixed "あぼーん" sentinel, not the real timestamp — see
+    // eddist-core's get_sjis_bytes / eddist-admin's convert_reses_to_dat_file for why:
+    // unlike name/mail/body (user- or admin-editable free text), date is never derived
+    // from any editable input, so it can't collide with a genuine post that spoofs
+    // name="あぼーん"/body="あぼーん" to mimic a deleted line.
+    const aboneKeepIdRegex = /^あぼーん<>あぼーん<>あぼーん ID:(.*)<> あぼーん <>(.*)$/;
+    const aboneKeepIdMatch = line.match(aboneKeepIdRegex);
+    if (aboneKeepIdMatch != null) {
+      const authorId = aboneKeepIdMatch[1];
+      if (idx === 0) {
+        threadTitle = aboneKeepIdMatch[2];
+      }
+
+      if (authorIdAppearBeforeCountMap.has(authorId)) {
+        const count = authorIdAppearBeforeCountMap.get(authorId) ?? 0;
+        authorIdAppearBeforeCountMap.set(authorId, count + 1);
+      } else {
+        authorIdAppearBeforeCountMap.set(authorId, 1);
+      }
+
+      const response = {
+        name: "あぼーん",
+        mail: "",
+        date: "",
+        authorId,
+        bodyParts: [{ text: "あぼーん", isMatch: false }],
+        id: idx + 1,
+        authorIdAppearBeforeCount: authorIdAppearBeforeCountMap.get(authorId) ?? 0,
+      };
+
+      if (!idMap.has(authorId)) {
+        idMap.set(authorId, []);
+      }
+      idMap.get(authorId)?.push([response, idx]);
+
+      return response;
+    }
+
     const lineRegex = /^(.*)<>(.*)<>(.*) ID:(.*)<>(.*)<>(.*)$/;
     const match = line.match(lineRegex);
     if (match == null) {
-      // あぼーん<>あぼーん<><> あぼーん<> てす
-      const aboneRegex = /^(.*)<>(.*)<><> あぼーん <>(.*)$/;
-      const aboneMatch = line.match(aboneRegex);
-      if (aboneMatch == null) {
+      // あぼーん, author_id stripped: あぼーん<>あぼーん<><> あぼーん <>{title}
+      const aboneStripRegex = /^(.*)<>(.*)<><> あぼーん <>(.*)$/;
+      const aboneStripMatch = line.match(aboneStripRegex);
+      if (aboneStripMatch == null) {
         // 1001 stopper line: "1001<><>Over 1000 Thread<>{body}<>"
         const stopperRegex = /^(.*)<>(.*)<>Over 1000 Thread<>(.*)<>(.*)$/;
         const stopperMatch = line.match(stopperRegex);
@@ -111,11 +150,11 @@ const convertThreadTextToResponseList = (text: string) => {
       }
 
       if (idx === 0) {
-        threadTitle = aboneMatch[3];
+        threadTitle = aboneStripMatch[3];
       }
 
       return {
-        name: aboneMatch[1],
+        name: aboneStripMatch[1],
         mail: "",
         date: "",
         authorId: "",

--- a/eddist-server/src/domain/res.rs
+++ b/eddist-server/src/domain/res.rs
@@ -49,6 +49,7 @@ pub struct Res<T: ResState> {
     metadent_type: MetadentType,
     client_info: ClientInfo,
     is_abone: bool,
+    is_abone_keep_id: bool,
     is_email_authed: bool,
     board_key: String,
     urls: Option<Vec<String>>,
@@ -248,6 +249,7 @@ impl Res<AuthorIdUninitialized> {
             metadent_type,
             client_info,
             is_abone,
+            is_abone_keep_id: false,
             is_email_authed,
             board_key: board_key.to_string(),
             urls: None,
@@ -350,6 +352,7 @@ impl Res<AuthorIdUninitialized> {
             metadent_type: self.metadent_type,
             client_info: self.client_info,
             is_abone: self.is_abone,
+            is_abone_keep_id: self.is_abone_keep_id,
             is_email_authed: self.is_email_authed,
             board_key: self.board_key,
             urls: self.urls,
@@ -410,6 +413,7 @@ impl Res<AuthorIdInitialized> {
             created_at: self.created_at,
             author_id: self.author_id(),
             is_abone: self.is_abone,
+            is_abone_keep_id: self.is_abone_keep_id,
         };
 
         eddist_core::domain::res::get_sjis_bytes(res_view_ref, default_name, thread_title)
@@ -425,6 +429,7 @@ impl From<Res<AuthorIdInitialized>> for ResView {
             created_at: res.created_at,
             author_id: res.author_id.unwrap(),
             is_abone: res.is_abone,
+            is_abone_keep_id: res.is_abone_keep_id,
         }
     }
 }
@@ -649,6 +654,7 @@ plainexample.com appears and finally ttp://fake.com/aaa.vvv for a test
                 tinker: None,
             },
             is_abone: false,
+            is_abone_keep_id: false,
             is_email_authed: false,
             board_key: "".to_string(),
             urls: None,
@@ -692,6 +698,7 @@ plainexample.com appears and finally ttp://fake.com/aaa.vvv for a test
                 tinker: None,
             },
             is_abone: false,
+            is_abone_keep_id: false,
             is_email_authed: false,
             board_key: "".to_string(),
             urls: None,

--- a/eddist-server/src/repositories/bbs_repository/response.rs
+++ b/eddist-server/src/repositories/bbs_repository/response.rs
@@ -23,7 +23,8 @@ impl ResponseRepository for BbsRepositoryImpl {
                 body,
                 created_at,
                 author_id,
-                is_abone AS "is_abone: bool"
+                is_abone AS "is_abone: bool",
+                is_abone_keep_id AS "is_abone_keep_id: bool"
             FROM responses WHERE thread_id = ?
             ORDER BY res_order, id"#,
             thread_id
@@ -40,6 +41,7 @@ impl ResponseRepository for BbsRepositoryImpl {
                 created_at: Utc.from_utc_datetime(&x.created_at),
                 author_id: x.author_id,
                 is_abone: x.is_abone,
+                is_abone_keep_id: x.is_abone_keep_id,
             })
             .collect())
     }
@@ -126,4 +128,5 @@ struct SelectionRes {
     created_at: NaiveDateTime,
     author_id: String,
     is_abone: bool,
+    is_abone_keep_id: bool,
 }

--- a/migrations/20260729140206_add_is_abone_keep_id_to_responses.down.sql
+++ b/migrations/20260729140206_add_is_abone_keep_id_to_responses.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE responses DROP COLUMN is_abone_keep_id, ALGORITHM=INSTANT;

--- a/migrations/20260729140206_add_is_abone_keep_id_to_responses.up.sql
+++ b/migrations/20260729140206_add_is_abone_keep_id_to_responses.up.sql
@@ -1,0 +1,6 @@
+-- Add up migration script here
+-- responses is a small, actively-churned table (only currently-active threads live here),
+-- so this is safe as an instant, metadata-only DDL. archived_responses is intentionally NOT
+-- touched: it is a huge table and the abone-keep-id feature doesn't need it there (the
+-- S3-archived dat path is self-describing from the dat text itself).
+ALTER TABLE responses ADD COLUMN is_abone_keep_id BOOLEAN NOT NULL DEFAULT FALSE, ALGORITHM=INSTANT;

--- a/migrations/20260729140206_add_is_abone_keep_id_to_responses.up.sql
+++ b/migrations/20260729140206_add_is_abone_keep_id_to_responses.up.sql
@@ -1,6 +1,2 @@
 -- Add up migration script here
--- responses is a small, actively-churned table (only currently-active threads live here),
--- so this is safe as an instant, metadata-only DDL. archived_responses is intentionally NOT
--- touched: it is a huge table and the abone-keep-id feature doesn't need it there (the
--- S3-archived dat path is self-describing from the dat text itself).
 ALTER TABLE responses ADD COLUMN is_abone_keep_id BOOLEAN NOT NULL DEFAULT FALSE, ALGORITHM=INSTANT;


### PR DESCRIPTION
- Add is_abone_keep_id (responses table only, instant DDL; archived_responses untouched) and thread it through eddist-core rendering, eddist-server, eddist-admin API/UI, and eddist-cron convert/backfill-convert paths
- Support the same option for S3-archived dat threads without any DB schema change, by relaxing the dat-text abone detector to recognize ID-kept lines
- Update eddist-client-v2's dat parser to recognize the new abone-keep-id line format and correctly wire it into the author-id popup/count map
- Regenerate eddist-admin OpenAPI spec and TypeScript client types
