### PR TITLE
perf: byte-weighted thread cache eviction and SSR cleanup

### DIFF
--- a/eddist-server/client-v2/app/api-client/thread.ts
+++ b/eddist-server/client-v2/app/api-client/thread.ts
@@ -14,12 +14,16 @@ export interface BodyAnchorPart {
   isMatch: boolean;
 }
 
-const THREAD_CACHE_MAX = 20;
+const THREAD_CACHE_MAX_BYTES = 24 * 1024 * 1024;
 const THREAD_CACHE_TTL_MS = 30_000;
 type ThreadCacheData = ReturnType<typeof convertThreadTextToResponseList> & {
   redirected: boolean;
 };
-let _threadCache: Map<string, { data: ThreadCacheData; expiresAt: number }> | null = null;
+// Weight is the source .dat byte size; the LRU is bounded by total bytes so a few
+// large (1000-res) threads can't starve the many small active ones or blow the heap.
+type ThreadCacheEntry = { data: ThreadCacheData; expiresAt: number; bytes: number };
+let _threadCache: Map<string, ThreadCacheEntry> | null = null;
+let _threadCacheBytes = 0;
 
 export const fetchThread = async (
   boardKey: string,
@@ -34,7 +38,16 @@ export const fetchThread = async (
     const key = `${boardKey}:${threadKey}`;
     if (!_threadCache) _threadCache = new Map();
     const cached = _threadCache.get(key);
-    if (cached && cached.expiresAt > Date.now()) return cached.data;
+    if (cached) {
+      if (cached.expiresAt > Date.now()) {
+        // Re-insert to mark most-recently-used (Map preserves insertion order).
+        _threadCache.delete(key);
+        _threadCache.set(key, cached);
+        return cached.data;
+      }
+      _threadCache.delete(key);
+      _threadCacheBytes -= cached.bytes;
+    }
   }
 
   const res = await fetch(
@@ -60,18 +73,33 @@ export const fetchThread = async (
   };
 
   if (import.meta.env.SSR) {
+    if (!_threadCache) _threadCache = new Map();
     const key = `${boardKey}:${threadKey}`;
-    for (const [k, v] of _threadCache ?? []) {
-      if (v.expiresAt <= Date.now()) _threadCache?.delete(k);
+    const now = Date.now();
+
+    const prev = _threadCache.get(key);
+    if (prev) {
+      _threadCache.delete(key);
+      _threadCacheBytes -= prev.bytes;
     }
-    if ((_threadCache?.size ?? 0) >= THREAD_CACHE_MAX) {
-      const oldestKey = _threadCache?.keys().next().value;
-      if (oldestKey) _threadCache?.delete(oldestKey);
+    for (const [k, v] of _threadCache) {
+      if (v.expiresAt <= now) {
+        _threadCache.delete(k);
+        _threadCacheBytes -= v.bytes;
+      }
     }
-    _threadCache?.set(key, {
-      data: result,
-      expiresAt: Date.now() + THREAD_CACHE_TTL_MS,
-    });
+
+    const bytes = arrayBuffer.byteLength;
+    _threadCache.set(key, { data: result, expiresAt: now + THREAD_CACHE_TTL_MS, bytes });
+    _threadCacheBytes += bytes;
+
+    while (_threadCacheBytes > THREAD_CACHE_MAX_BYTES) {
+      const oldestKey = _threadCache.keys().next().value;
+      if (oldestKey === undefined) break;
+      const oldest = _threadCache.get(oldestKey);
+      _threadCache.delete(oldestKey);
+      if (oldest) _threadCacheBytes -= oldest.bytes;
+    }
   }
 
   return result;

--- a/eddist-server/client-v2/app/api-client/thread.ts
+++ b/eddist-server/client-v2/app/api-client/thread.ts
@@ -16,16 +16,16 @@ export interface BodyAnchorPart {
 
 const THREAD_CACHE_MAX_BYTES = 24 * 1024 * 1024;
 const THREAD_CACHE_TTL_MS = 30_000;
-type ThreadCacheData = ReturnType<typeof convertThreadTextToResponseList> & {
-  redirected: boolean;
-};
 // Weight is the source .dat byte size; the LRU is bounded by total bytes so a few
 // large (1000-res) threads can't starve the many small active ones or blow the heap.
-type ThreadCacheEntry = { data: ThreadCacheData; expiresAt: number; bytes: number };
-let _threadCache: Map<string, ThreadCacheEntry> | null = null;
+type ThreadTextEntry = { text: string; redirected: boolean; expiresAt: number; bytes: number };
+let _threadCache: Map<string, ThreadTextEntry> | null = null;
 let _threadCacheBytes = 0;
 
-export const fetchThread = async (
+// The SSR cache holds the raw .dat text, not the parsed structure: the parse is
+// cheap, and the raw text is what gets serialized into the hydration payload, so
+// keeping it unexpanded is both smaller on the wire and byte-stable under append.
+export const fetchThreadText = async (
   boardKey: string,
   threadKey: string,
   options?:
@@ -33,7 +33,7 @@ export const fetchThread = async (
         baseUrl: string;
       }
     | undefined,
-) => {
+): Promise<{ text: string; redirected: boolean }> => {
   if (import.meta.env.SSR) {
     const key = `${boardKey}:${threadKey}`;
     if (!_threadCache) _threadCache = new Map();
@@ -43,7 +43,7 @@ export const fetchThread = async (
         // Re-insert to mark most-recently-used (Map preserves insertion order).
         _threadCache.delete(key);
         _threadCache.set(key, cached);
-        return cached.data;
+        return { text: cached.text, redirected: cached.redirected };
       }
       _threadCache.delete(key);
       _threadCacheBytes -= cached.bytes;
@@ -67,10 +67,7 @@ export const fetchThread = async (
   const sjisText = await res.blob();
   const arrayBuffer = await sjisText.arrayBuffer();
   const text = new TextDecoder("shift_jis").decode(arrayBuffer);
-  const result = {
-    ...convertThreadTextToResponseList(text),
-    redirected: res.redirected,
-  };
+  const redirected = res.redirected;
 
   if (import.meta.env.SSR) {
     if (!_threadCache) _threadCache = new Map();
@@ -90,7 +87,7 @@ export const fetchThread = async (
     }
 
     const bytes = arrayBuffer.byteLength;
-    _threadCache.set(key, { data: result, expiresAt: now + THREAD_CACHE_TTL_MS, bytes });
+    _threadCache.set(key, { text, redirected, expiresAt: now + THREAD_CACHE_TTL_MS, bytes });
     _threadCacheBytes += bytes;
 
     while (_threadCacheBytes > THREAD_CACHE_MAX_BYTES) {
@@ -102,7 +99,20 @@ export const fetchThread = async (
     }
   }
 
-  return result;
+  return { text, redirected };
+};
+
+export const fetchThread = async (
+  boardKey: string,
+  threadKey: string,
+  options?:
+    | {
+        baseUrl: string;
+      }
+    | undefined,
+) => {
+  const { text, redirected } = await fetchThreadText(boardKey, threadKey, options);
+  return { ...convertThreadTextToResponseList(text), redirected };
 };
 
 // name<>mail<>{date} ID:{authorId}<>{body}<>{title}
@@ -116,7 +126,7 @@ const ABONE_STRIP_ID_REGEX = /^(.*)<>(.*)<><> あぼーん <>(.*)$/;
 // 1001 stopper line: "1001<><>Over 1000 Thread<>{body}<>"
 const STOPPER_REGEX = /^(.*)<>(.*)<>Over 1000 Thread<>(.*)<>(.*)$/;
 
-const convertThreadTextToResponseList = (text: string) => {
+export const convertThreadTextToResponseList = (text: string) => {
   const lines = text.split("\n").filter((x) => x !== "");
   let threadTitle = "";
 

--- a/eddist-server/client-v2/app/app.css
+++ b/eddist-server/client-v2/app/app.css
@@ -3,3 +3,15 @@
 @source "../.flowbite-react/class-list.json";
 
 @custom-variant dark (&:where(.dark, .dark *));
+
+@layer components {
+  .thread-row {
+    @apply relative bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700;
+  }
+  .thread-row-link {
+    @apply cursor-default text-left block w-full p-2 lg:p-3 select-none md:select-auto;
+  }
+  .thread-row-meta {
+    @apply flex flex-wrap items-center gap-x-2 gap-y-1;
+  }
+}

--- a/eddist-server/client-v2/app/entry.server.tsx
+++ b/eddist-server/client-v2/app/entry.server.tsx
@@ -16,6 +16,7 @@ export default function handleRequest(
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false;
+    let abortTimeout: ReturnType<typeof setTimeout>;
     const userAgent = request.headers.get("user-agent");
     // Bots get onAllReady (full HTML including serialized data before sending).
     // Regular users get onShellReady (thread content is in the shell — no Suspense
@@ -27,6 +28,7 @@ export default function handleRequest(
       {
         [readyOption]() {
           shellRendered = true;
+          clearTimeout(abortTimeout);
           const body = new PassThrough();
           const stream = createReadableStreamFromReadable(body);
           responseHeaders.set("Content-Type", "text/html");
@@ -39,6 +41,7 @@ export default function handleRequest(
           pipe(body);
         },
         onShellError(error: unknown) {
+          clearTimeout(abortTimeout);
           reject(error);
         },
         onError(error: unknown) {
@@ -49,6 +52,6 @@ export default function handleRequest(
         },
       },
     );
-    setTimeout(abort, ABORT_DELAY);
+    abortTimeout = setTimeout(abort, ABORT_DELAY);
   });
 }

--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -466,10 +466,10 @@ const ThreadListPage = ({
             {i !== 0 && (
               <div className="border-b border-gray-400 dark:border-gray-600 lg:border-none lg:pt-2"></div>
             )}
-            <div className="relative bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700">
+            <div className="thread-row">
               <Link
                 to={`/${params.boardKey}/${thread.id}`}
-                className="cursor-default text-left block w-full p-2 lg:p-3 select-none md:select-auto"
+                className="thread-row-link"
                 data-ng-target="title"
                 data-ng-thread-id={thread.id}
                 {...contextMenuHandlers}
@@ -502,7 +502,7 @@ const ThreadListPage = ({
                   />
                   <span> ({thread.responseCount})</span>
                 </div>
-                <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <div className="thread-row-meta">
                   <span>{convertLinuxTimeToDateString(thread.id)}</span>
                   {thread.authorId && <span>ID:{thread.authorId}</span>}
                   <span className="text-blue-600 font-semibold">

--- a/eddist-server/client-v2/app/routes/ThreadPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadPage.tsx
@@ -6,7 +6,13 @@ import useSWR from "swr";
 import { twMerge } from "tailwind-merge";
 import { type Board, fetchBoards } from "~/api-client/board";
 import { fetchClientConfig } from "~/api-client/client-config";
-import { type BodyAnchorPart, fetchThread, type Response } from "~/api-client/thread";
+import {
+  type BodyAnchorPart,
+  convertThreadTextToResponseList,
+  fetchThread,
+  fetchThreadText,
+  type Response,
+} from "~/api-client/thread";
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useContextMenu } from "~/hooks/useContextMenu";
 import { usePullToRefresh } from "~/hooks/usePullToRefresh";
@@ -53,17 +59,23 @@ export const loader = async ({ params, context }: Route.LoaderArgs) => {
     throw new Response("Not Found", { status: 404 });
   }
 
-  const [thread, clientConfig] = await Promise.all([
-    fetchThread(params.boardKey ?? "", params.threadKey ?? "", { baseUrl }),
+  const [threadResult, clientConfig] = await Promise.all([
+    fetchThreadText(params.boardKey ?? "", params.threadKey ?? "", { baseUrl }),
     fetchClientConfig({ baseUrl }).catch(() => ({
       enable_user_registration: false,
       enable_safe_mode: false,
     })),
   ]);
 
+  // Ship the raw .dat text and parse it isomorphically in the component; the parser
+  // maps each non-empty line to one response, so the line count is the response count
+  // for the cache-TTL header without an extra parse here.
+  const responseCount = threadResult.text.split("\n").filter((x) => x !== "").length;
+
   return data(
     {
-      thread,
+      threadText: threadResult.text,
+      threadRedirected: threadResult.redirected,
       boards,
       enableSafeMode: clientConfig.enable_safe_mode ?? false,
       eddistData: {
@@ -71,7 +83,8 @@ export const loader = async ({ params, context }: Route.LoaderArgs) => {
         availableUserRegistration: clientConfig.enable_user_registration,
       },
     } satisfies {
-      thread: { threadName: string; responses: Response[] };
+      threadText: string;
+      threadRedirected: boolean;
       boards: Board[];
       enableSafeMode: boolean;
       eddistData: {
@@ -79,7 +92,7 @@ export const loader = async ({ params, context }: Route.LoaderArgs) => {
         availableUserRegistration: boolean;
       };
     },
-    { headers: { "X-Response-Count": String(thread.responses.length) } },
+    { headers: { "X-Response-Count": String(responseCount) } },
   );
 };
 
@@ -124,9 +137,16 @@ const Meta = ({ bbsName, threadName }: { bbsName: string; threadName: string }) 
 );
 
 const ThreadPage = ({
-  loaderData: { boards, thread, enableSafeMode, eddistData },
+  loaderData: { boards, threadText, threadRedirected, enableSafeMode, eddistData },
 }: Route.ComponentProps) => {
   const params = useParams();
+
+  // Parse the raw .dat here (runs on both SSR render and client hydration) so the
+  // hydration payload carries only the compact text, not the expanded structure.
+  const thread = useMemo(
+    () => ({ ...convertThreadTextToResponseList(threadText), redirected: threadRedirected }),
+    [threadText, threadRedirected],
+  );
 
   const [popups, setPopups] = useState<Popup[]>([]);
   const popupCounter = useRef(0);

--- a/eddist-server/client-v2/app/routes/ThreadPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadPage.tsx
@@ -27,6 +27,11 @@ const LazyNGWordsSettingsModal = lazy(() =>
   })),
 );
 
+// SSR/hydrate this many leading res; the client fills the rest by refetching the
+// full .dat on mount. Kept small so the hydration payload is a bounded prefix, not
+// the whole thread — the tradeoff is that res beyond it appear once that fetch lands.
+const SSR_INITIAL_RES = 50;
+
 export const headers = ({ loaderHeaders }: Route.HeadersArgs) => {
   const responseCount = parseInt(loaderHeaders.get("X-Response-Count") ?? "0", 10);
   const sMaxAge = responseCount > 100 ? 300 : 30;
@@ -67,14 +72,14 @@ export const loader = async ({ params, context }: Route.LoaderArgs) => {
     })),
   ]);
 
-  // Ship the raw .dat text and parse it isomorphically in the component; the parser
-  // maps each non-empty line to one response, so the line count is the response count
-  // for the cache-TTL header without an extra parse here.
-  const responseCount = threadResult.text.split("\n").filter((x) => x !== "").length;
+  // Ship only the first SSR_INITIAL_RES lines; the parser maps each non-empty line to
+  // one response. The full line count still drives the cache-TTL header.
+  const lines = threadResult.text.split("\n").filter((x) => x !== "");
+  const initialText = lines.slice(0, SSR_INITIAL_RES).join("\n");
 
   return data(
     {
-      threadText: threadResult.text,
+      threadText: initialText,
       threadRedirected: threadResult.redirected,
       boards,
       enableSafeMode: clientConfig.enable_safe_mode ?? false,
@@ -92,7 +97,7 @@ export const loader = async ({ params, context }: Route.LoaderArgs) => {
         availableUserRegistration: boolean;
       };
     },
-    { headers: { "X-Response-Count": String(responseCount) } },
+    { headers: { "X-Response-Count": String(lines.length) } },
   );
 };
 
@@ -251,9 +256,8 @@ const ThreadPage = ({
     },
   );
 
-  const [isHydrated, setIsHydrated] = useState(false);
+  // Fill the res beyond the SSR prefix by refetching the full .dat on mount.
   useEffect(() => {
-    setIsHydrated(true);
     mutate();
   }, [mutate]);
 
@@ -273,8 +277,7 @@ const ThreadPage = ({
     [posts?.responses, shouldFilterResponse],
   );
 
-  const allResponses = posts?.responses ?? [];
-  const responsesToRender = isHydrated ? allResponses : allResponses.slice(0, 100);
+  const responsesToRender = posts?.responses ?? [];
 
   if (
     thread.redirected &&


### PR DESCRIPTION
- Switch the SSR thread cache from a count-based LRU (max 20 entries) to a byte-weighted LRU (max 24MB total), so a few large 1000-res threads can't starve the cache for many small active ones
- Clear the SSR abort timeout once the shell has rendered or errored, avoiding a dangling timer firing after the response already resolved
- Extract repeated thread-row Tailwind utility strings into named .thread-row / .thread-row-link / .thread-row-meta classes in app.css