### PR TITLE
refactor: replace flowbite Button/Toast with local components in eddist-client

### DIFF
--- a/eddist-server/client-v2/app/components/FloatingNGButton.tsx
+++ b/eddist-server/client-v2/app/components/FloatingNGButton.tsx
@@ -1,8 +1,8 @@
-import { Button } from "flowbite-react";
 import { useEffect, useState } from "react";
 import { FaBan } from "react-icons/fa";
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useToast } from "~/contexts/ToastContext";
+import { Button } from "./ui/Button";
 
 interface SelectionInfo {
   text: string;

--- a/eddist-server/client-v2/app/components/ui/Button.tsx
+++ b/eddist-server/client-v2/app/components/ui/Button.tsx
@@ -1,0 +1,19 @@
+import type { ButtonHTMLAttributes } from "react";
+import { twMerge } from "tailwind-merge";
+
+const BASE =
+  "flex items-center justify-center rounded-lg text-center font-medium text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800";
+const SIZES = { sm: "text-sm px-3 py-1.5", md: "text-sm px-4 py-2" } as const;
+
+export const Button = ({
+  size = "md",
+  color: _color,
+  type = "button",
+  className,
+  children,
+  ...rest
+}: ButtonHTMLAttributes<HTMLButtonElement> & { size?: "sm" | "md"; color?: string }) => (
+  <button type={type} className={twMerge(BASE, SIZES[size], className)} {...rest}>
+    {children}
+  </button>
+);

--- a/eddist-server/client-v2/app/contexts/ToastContext.tsx
+++ b/eddist-server/client-v2/app/contexts/ToastContext.tsx
@@ -1,4 +1,3 @@
-import { Toast } from "flowbite-react";
 import { createContext, type ReactNode, useCallback, useContext, useState } from "react";
 import { HiCheck, HiX } from "react-icons/hi";
 
@@ -48,7 +47,10 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
       {/* Toast container - fixed position at top-right */}
       <div className="fixed top-4 right-4 z-50 flex flex-col gap-2">
         {toasts.map((toast) => (
-          <Toast key={toast.id}>
+          <div
+            key={toast.id}
+            className="flex items-center w-full max-w-xs p-4 text-gray-500 bg-white rounded-lg shadow dark:text-gray-400 dark:bg-gray-800"
+          >
             <div
               className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${
                 toast.type === "success"
@@ -71,7 +73,7 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
             >
               <HiX className="h-5 w-5" />
             </button>
-          </Toast>
+          </div>
         ))}
       </div>
     </ToastContext.Provider>

--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -1,4 +1,3 @@
-import { Button } from "flowbite-react";
 import { lazy, Suspense, useMemo, useRef, useState } from "react";
 import { FaArrowLeft, FaCog, FaPen, FaSort, FaSortDown, FaSortUp, FaSync } from "react-icons/fa";
 import { Link, useParams } from "react-router";
@@ -17,6 +16,7 @@ import { parseCookie } from "~/utils/cookie";
 import { getSelectedTextInElement } from "~/utils/selection";
 import { NGContextMenu } from "../components/NGContextMenu";
 import { ThreadSummarizeButton } from "../components/ThreadSummarizeButton";
+import { Button } from "../components/ui/Button";
 import type { Route } from "./+types/ThreadListPage";
 
 const LazyPostThreadModal = lazy(() => import("../components/PostThreadModal"));

--- a/eddist-server/client-v2/app/routes/ThreadPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadPage.tsx
@@ -1,4 +1,3 @@
-import { Button } from "flowbite-react";
 import React, { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { FaArrowLeft, FaCog, FaPen, FaSync } from "react-icons/fa";
 import { data, Link, useParams } from "react-router";
@@ -18,6 +17,7 @@ import { useContextMenu } from "~/hooks/useContextMenu";
 import { usePullToRefresh } from "~/hooks/usePullToRefresh";
 import { FloatingNGButton } from "../components/FloatingNGButton";
 import { NGContextMenu } from "../components/NGContextMenu";
+import { Button } from "../components/ui/Button";
 import type { Route } from "./+types/ThreadPage";
 
 const LazyPostResponseModal = lazy(() => import("../components/PostResponseModal"));


### PR DESCRIPTION
- Add local ui/Button component and use it in ThreadPage, ThreadListPage, and FloatingNGButton in place of flowbite-react's Button
- Replace flowbite Toast with a plain styled div in ToastContext

