### PR TITLE
feat: allow suspend/unsuspend of authed tokens from admin UI and internal API

### DIFF
--- a/eddist-admin/client/app/hooks/queries/authed-tokens.ts
+++ b/eddist-admin/client/app/hooks/queries/authed-tokens.ts
@@ -75,3 +75,38 @@ export const useClearReAuth = () => {
     onError: () => toast.error("Failed to clear re-auth requirement"),
   });
 };
+
+const SUSPEND_TOKEN = "/authed_tokens/{authed_token_id}/suspend";
+
+export const useSuspendToken = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (args: { authedTokenId: string; ttlSeconds: number }) => {
+      await client.POST(SUSPEND_TOKEN, {
+        params: { path: { authed_token_id: args.authedTokenId } },
+        body: { ttl_seconds: args.ttlSeconds },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [LIST_AUTHED_TOKENS] });
+      toast.success("Token suspended");
+    },
+    onError: () => toast.error("Failed to suspend token"),
+  });
+};
+
+export const useUnsuspendToken = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (authedTokenId: string) => {
+      await client.DELETE(SUSPEND_TOKEN, {
+        params: { path: { authed_token_id: authedTokenId } },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [LIST_AUTHED_TOKENS] });
+      toast.success("Token unsuspended");
+    },
+    onError: () => toast.error("Failed to unsuspend token"),
+  });
+};

--- a/eddist-admin/client/app/openapi/schema.d.ts
+++ b/eddist-admin/client/app/openapi/schema.d.ts
@@ -69,6 +69,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/authed_tokens/{authed_token_id}/suspend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["suspend_token"];
+        delete: operations["unsuspend_token"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/boards/": {
         parameters: {
             query?: never;
@@ -614,6 +630,7 @@ export interface components {
             created_at: string;
             /** Format: uuid */
             id: string;
+            is_suspended?: boolean | null;
             /** Format: date-time */
             last_wrote_at?: string | null;
             origin_ip: string;
@@ -902,6 +919,10 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
             value: string;
+        };
+        SuspendAuthedTokenBody: {
+            /** Format: int64 */
+            ttl_seconds: number;
         };
         /** @description Terms model for API documentation */
         Terms: {
@@ -1213,6 +1234,52 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Cleared require re-auth successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    suspend_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Authed token ID */
+                authed_token_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SuspendAuthedTokenBody"];
+            };
+        };
+        responses: {
+            /** @description Suspended token successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    unsuspend_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Authed token ID */
+                authed_token_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unsuspended token successfully */
             204: {
                 headers: {
                     [name: string]: unknown;

--- a/eddist-admin/client/app/routes/dashboard.authed-token.tsx
+++ b/eddist-admin/client/app/routes/dashboard.authed-token.tsx
@@ -30,6 +30,8 @@ import {
   useClearReAuth,
   useDeleteAuthedToken,
   useRequireReAuth,
+  useSuspendToken,
+  useUnsuspendToken,
 } from "~/hooks/queries";
 import client from "~/openapi/client";
 import type { components } from "~/openapi/schema";
@@ -42,6 +44,8 @@ const Page = () => {
   const deleteAuthedTokenMutation = useDeleteAuthedToken();
   const requireReAuthMutation = useRequireReAuth();
   const clearReAuthMutation = useClearReAuth();
+  const suspendTokenMutation = useSuspendToken();
+  const unsuspendTokenMutation = useUnsuspendToken();
 
   // Open detail modal when navigating with ?token=<id> from responses page
   useEffect(() => {
@@ -99,6 +103,14 @@ const Page = () => {
   // Detail modal
   const [selectedToken, setSelectedToken] = useState<AuthedToken | null>(null);
   const [showAdditionalInfo, setShowAdditionalInfo] = useState(false);
+  const [suspendTtlMinutes, setSuspendTtlMinutes] = useState("60");
+
+  const handleSelectToken = useCallback(async (authedTokenId: string) => {
+    const { data } = await client.GET("/authed_tokens/{authed_token_id}/", {
+      params: { path: { authed_token_id: authedTokenId } },
+    });
+    if (data) setSelectedToken(data);
+  }, []);
 
   const queryParams = useMemo(
     () => ({
@@ -150,6 +162,24 @@ const Page = () => {
       { onSuccess: () => setSelectedToken(null) },
     );
   }, [selectedToken?.id, selectedToken?.origin_ip, deleteAuthedTokenMutation]);
+
+  const handleSuspendToken = useCallback(() => {
+    if (!selectedToken?.id) return;
+    const ttlSeconds = Number(suspendTtlMinutes) * 60;
+    if (!ttlSeconds || ttlSeconds <= 0) return;
+    if (!confirm(`Suspend this token for ${suspendTtlMinutes} minute(s)?`)) return;
+    suspendTokenMutation.mutate(
+      { authedTokenId: selectedToken.id, ttlSeconds },
+      { onSuccess: () => setSelectedToken({ ...selectedToken, is_suspended: true }) },
+    );
+  }, [selectedToken, suspendTtlMinutes, suspendTokenMutation]);
+
+  const handleUnsuspendToken = useCallback(() => {
+    if (!selectedToken?.id) return;
+    unsuspendTokenMutation.mutate(selectedToken.id, {
+      onSuccess: () => setSelectedToken({ ...selectedToken, is_suspended: false }),
+    });
+  }, [selectedToken, unsuspendTokenMutation]);
 
   const columns = useMemo<ColumnDef<AuthedToken>[]>(
     () => [
@@ -402,7 +432,7 @@ const Page = () => {
                 <TableRow
                   key={row.id}
                   className="cursor-pointer hover:bg-gray-50"
-                  onClick={() => setSelectedToken(row.original)}
+                  onClick={() => handleSelectToken(row.original.id)}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>
@@ -474,6 +504,11 @@ const Page = () => {
             {selectedToken && (
               <Badge color={selectedToken.validity ? "success" : "failure"} size="sm">
                 {selectedToken.validity ? "Valid" : "Revoked"}
+              </Badge>
+            )}
+            {selectedToken?.is_suspended && (
+              <Badge color="warning" size="sm">
+                Suspended
               </Badge>
             )}
           </div>
@@ -635,6 +670,37 @@ const Page = () => {
                       Clear Re-Auth
                     </Button>
                   )}
+                  {selectedToken.is_suspended ? (
+                    <Button color="gray" size="sm" onClick={handleUnsuspendToken}>
+                      Unsuspend
+                    </Button>
+                  ) : (
+                    <div className="flex items-end gap-2">
+                      <div>
+                        <Label htmlFor="suspend-ttl" className="mb-1 block text-xs">
+                          Suspend for (minutes)
+                        </Label>
+                        <TextInput
+                          id="suspend-ttl"
+                          sizing="sm"
+                          type="number"
+                          min={1}
+                          className="w-28"
+                          value={suspendTtlMinutes}
+                          onChange={(e) => setSuspendTtlMinutes(e.target.value)}
+                          disabled={selectedToken.validity === false}
+                        />
+                      </div>
+                      <Button
+                        color="warning"
+                        size="sm"
+                        onClick={handleSuspendToken}
+                        disabled={selectedToken.validity === false}
+                      >
+                        Suspend
+                      </Button>
+                    </div>
+                  )}
                 </div>
                 {selectedToken.validity === false && (
                   <p className="text-sm text-gray-500 mt-2">This token has already been revoked.</p>
@@ -642,6 +708,11 @@ const Page = () => {
                 {selectedToken.require_reauth && (
                   <p className="text-sm text-yellow-600 mt-2">
                     This token requires re-authentication before posting.
+                  </p>
+                )}
+                {selectedToken.is_suspended && (
+                  <p className="text-sm text-yellow-600 mt-2">
+                    This token is temporarily suspended from posting.
                   </p>
                 )}
               </div>

--- a/eddist-admin/openapi.json
+++ b/eddist-admin/openapi.json
@@ -280,6 +280,64 @@
         }
       }
     },
+    "/authed_tokens/{authed_token_id}/suspend": {
+      "post": {
+        "tags": [
+          "auth_tokens"
+        ],
+        "operationId": "suspend_token",
+        "parameters": [
+          {
+            "name": "authed_token_id",
+            "in": "path",
+            "description": "Authed token ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SuspendAuthedTokenBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Suspended token successfully"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "auth_tokens"
+        ],
+        "operationId": "unsuspend_token",
+        "parameters": [
+          {
+            "name": "authed_token_id",
+            "in": "path",
+            "description": "Authed token ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Unsuspended token successfully"
+          }
+        }
+      }
+    },
     "/boards/": {
       "get": {
         "tags": [
@@ -2353,6 +2411,12 @@
             "type": "string",
             "format": "uuid"
           },
+          "is_suspended": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "last_wrote_at": {
             "type": [
               "string",
@@ -3473,6 +3537,19 @@
           },
           "value": {
             "type": "string"
+          }
+        }
+      },
+      "SuspendAuthedTokenBody": {
+        "type": "object",
+        "required": [
+          "ttl_seconds"
+        ],
+        "properties": {
+          "ttl_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           }
         }
       },

--- a/eddist-admin/src/api_doc.rs
+++ b/eddist-admin/src/api_doc.rs
@@ -49,6 +49,8 @@ use crate::{
         auth_tokens::delete_authed_token,
         auth_tokens::require_reauth_token,
         auth_tokens::clear_require_reauth_token,
+        auth_tokens::suspend_token,
+        auth_tokens::unsuspend_token,
 
         // Moderation routes
         moderation::get_ng_words,
@@ -125,6 +127,7 @@ use crate::{
         AuthedToken,
         PaginatedAuthedTokens,
         DeleteAuthedTokenInput,
+        SuspendAuthedTokenBody,
         NativeSessionRequest,
         NativeSessionResponse,
         NativeUserInfo,

--- a/eddist-admin/src/models/auth.rs
+++ b/eddist-admin/src/models/auth.rs
@@ -18,6 +18,7 @@ pub struct AuthedToken {
     pub last_wrote_at: Option<NaiveDateTime>,
     pub additional_info: Option<serde_json::Value>,
     pub require_reauth: bool,
+    pub is_suspended: Option<bool>,
 }
 
 #[derive(Debug, Clone, IntoParams, Serialize, Deserialize)]
@@ -45,6 +46,11 @@ pub struct PaginatedAuthedTokens {
 #[derive(Debug, Clone, ToSchema, IntoParams, Serialize, Deserialize)]
 pub struct DeleteAuthedTokenInput {
     pub using_origin_ip: bool,
+}
+
+#[derive(Debug, Clone, ToSchema, Serialize, Deserialize)]
+pub struct SuspendAuthedTokenBody {
+    pub ttl_seconds: u64,
 }
 
 #[derive(Debug, Clone, ToSchema, Serialize, Deserialize)]

--- a/eddist-admin/src/repository/authed_token_repository.rs
+++ b/eddist-admin/src/repository/authed_token_repository.rs
@@ -38,6 +38,8 @@ impl From<AuthedTokenRow> for AuthedToken {
             last_wrote_at: row.last_wrote_at,
             additional_info: row.additional_info,
             require_reauth: row.require_reauth,
+            // Suspension lives in Redis, not this table; callers fill this in from there.
+            is_suspended: None,
         }
     }
 }

--- a/eddist-admin/src/routes/auth_tokens.rs
+++ b/eddist-admin/src/routes/auth_tokens.rs
@@ -10,7 +10,10 @@ use crate::{
     AppState,
     auth::AdminIdentity,
     error::ApiError,
-    models::{DeleteAuthedTokenInput, ListAuthedTokensQuery, PaginatedAuthedTokens},
+    models::{
+        DeleteAuthedTokenInput, ListAuthedTokensQuery, PaginatedAuthedTokens,
+        SuspendAuthedTokenBody,
+    },
 };
 
 pub fn routes() -> Router<AppState> {
@@ -24,6 +27,10 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/authed_tokens/{authedTokenId}/require-reauth",
             post(require_reauth_token).delete(clear_require_reauth_token),
+        )
+        .route(
+            "/authed_tokens/{authedTokenId}/suspend",
+            post(suspend_token).delete(unsuspend_token),
         )
 }
 
@@ -136,6 +143,55 @@ pub async fn clear_require_reauth_token(
         .services
         .authed_token
         .clear_require_reauth(authed_token_id)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    post,
+    path = "/authed_tokens/{authed_token_id}/suspend",
+    responses(
+        (status = 204, description = "Suspended token successfully"),
+    ),
+    params(
+        ("authed_token_id" = Uuid, Path, description = "Authed token ID"),
+    ),
+    request_body = SuspendAuthedTokenBody
+)]
+pub async fn suspend_token(
+    State(state): State<AppState>,
+    Path(authed_token_id): Path<Uuid>,
+    Json(body): Json<SuspendAuthedTokenBody>,
+) -> Result<StatusCode, ApiError> {
+    if body.ttl_seconds == 0 {
+        return Err(ApiError::bad_request("ttl_seconds must be greater than 0"));
+    }
+    state
+        .services
+        .authed_token
+        .suspend_authed_token(authed_token_id, body.ttl_seconds)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    delete,
+    path = "/authed_tokens/{authed_token_id}/suspend",
+    responses(
+        (status = 204, description = "Unsuspended token successfully"),
+    ),
+    params(
+        ("authed_token_id" = Uuid, Path, description = "Authed token ID"),
+    ),
+)]
+pub async fn unsuspend_token(
+    State(state): State<AppState>,
+    Path(authed_token_id): Path<Uuid>,
+) -> Result<StatusCode, ApiError> {
+    state
+        .services
+        .authed_token
+        .unsuspend_authed_token(authed_token_id)
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/eddist-admin/src/routes/internal.rs
+++ b/eddist-admin/src/routes/internal.rs
@@ -1,5 +1,10 @@
-use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
-use serde::Deserialize;
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{AppState, error::ApiError};
@@ -9,6 +14,11 @@ use super::auth_tokens::{clear_require_reauth_token, require_reauth_token};
 pub fn create_internal_routes() -> Router<AppState> {
     Router::new()
         .route("/authed-tokens/suspend", post(suspend_authed_token))
+        .route("/authed-tokens/unsuspend", post(unsuspend_authed_token))
+        .route(
+            "/authed-tokens/suspended",
+            get(list_suspended_authed_tokens),
+        )
         .route("/authed-tokens/revoke", post(revoke_authed_token))
         .route(
             "/authed-tokens/require-reauth/{authedTokenId}",
@@ -37,6 +47,48 @@ pub async fn suspend_authed_token(
         .await?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(Deserialize)]
+pub struct UnsuspendAuthedTokenInput {
+    pub authed_token_id: Uuid,
+}
+
+pub async fn unsuspend_authed_token(
+    State(state): State<AppState>,
+    Json(input): Json<UnsuspendAuthedTokenInput>,
+) -> Result<StatusCode, ApiError> {
+    state
+        .services
+        .authed_token
+        .unsuspend_authed_token(input.authed_token_id)
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(Serialize)]
+pub struct SuspendedAuthedToken {
+    pub authed_token_id: Uuid,
+    pub ttl_seconds: i64,
+}
+
+pub async fn list_suspended_authed_tokens(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<SuspendedAuthedToken>>, ApiError> {
+    let items = state
+        .services
+        .authed_token
+        .list_suspended_authed_tokens()
+        .await?
+        .into_iter()
+        .map(|(authed_token_id, ttl_seconds)| SuspendedAuthedToken {
+            authed_token_id,
+            ttl_seconds,
+        })
+        .collect();
+
+    Ok(Json(items))
 }
 
 #[derive(Deserialize)]

--- a/eddist-admin/src/services/authed_token_service.rs
+++ b/eddist-admin/src/services/authed_token_service.rs
@@ -33,6 +33,8 @@ pub trait AuthedTokenService: Send + Sync {
     async fn set_require_reauth(&self, id: Uuid) -> anyhow::Result<()>;
     async fn clear_require_reauth(&self, id: Uuid) -> anyhow::Result<()>;
     async fn suspend_authed_token(&self, id: Uuid, ttl_seconds: u64) -> anyhow::Result<()>;
+    async fn unsuspend_authed_token(&self, id: Uuid) -> anyhow::Result<()>;
+    async fn list_suspended_authed_tokens(&self) -> anyhow::Result<Vec<(Uuid, i64)>>;
     async fn revoke_authed_token(&self, actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()>;
 }
 
@@ -104,7 +106,11 @@ impl AuthedTokenService for AuthedTokenServiceImpl {
     }
 
     async fn get_authed_token(&self, id: Uuid) -> anyhow::Result<AuthedToken> {
-        self.repo.get_authed_token(id).await
+        let mut token = self.repo.get_authed_token(id).await?;
+        let key = authed_token_suspended_key(&id.to_string());
+        let mut conn = self.redis_conn.clone();
+        token.is_suspended = Some(conn.exists(&key).await.unwrap_or(false));
+        Ok(token)
     }
 
     async fn delete_authed_token(
@@ -149,6 +155,47 @@ impl AuthedTokenService for AuthedTokenServiceImpl {
         conn.set_ex::<_, _, ()>(&key, "1", ttl_seconds)
             .await
             .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    async fn unsuspend_authed_token(&self, id: Uuid) -> anyhow::Result<()> {
+        let key = authed_token_suspended_key(&id.to_string());
+        let mut conn = self.redis_conn.clone();
+        conn.del::<_, ()>(&key)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    async fn list_suspended_authed_tokens(&self) -> anyhow::Result<Vec<(Uuid, i64)>> {
+        let mut conn = self.redis_conn.clone();
+        let prefix = authed_token_suspended_key("");
+        let pattern = format!("{prefix}*");
+
+        let keys: Vec<String> = {
+            let mut iter: redis::AsyncIter<String> = conn
+                .scan_match(&pattern)
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let mut keys = Vec::new();
+            while let Some(key) = iter.next_item().await {
+                keys.push(key.map_err(|e| anyhow::anyhow!(e))?);
+            }
+            keys
+        };
+
+        let mut suspended = Vec::with_capacity(keys.len());
+        for key in keys {
+            let Some(id) = key
+                .strip_prefix(&prefix)
+                .and_then(|id_str| Uuid::parse_str(id_str).ok())
+            else {
+                continue;
+            };
+            let ttl: i64 = conn.ttl(&key).await.unwrap_or(-1);
+            if ttl > 0 {
+                suspended.push((id, ttl));
+            }
+        }
+        Ok(suspended)
     }
 
     async fn revoke_authed_token(&self, _actor: &AdminIdentity, id: Uuid) -> anyhow::Result<()> {


### PR DESCRIPTION
- Add is_suspended field to AuthedToken, populated from Redis on single-token fetch
- Add admin-facing POST/DELETE /authed_tokens/{id}/suspend routes so the authed-token admin page can suspend and unsuspend a token directly, mirroring the existing require-reauth POST/DELETE pattern
- Add unsuspend_authed_token and list_suspended_authed_tokens to AuthedTokenService, backed by Redis SCAN + TTL over the authed_token:suspended:* keyspace
- Add internal API endpoints (X-Internal-Secret gated) for unsuspend and listing currently suspended tokens, matching the existing internal suspend/revoke routes
- Wire up suspend/unsuspend buttons and a suspended badge in the authed-token admin page, and regenerate openapi.json/schema.d.ts