### PR TITLE
perf: SSR only the first 40 thread-list rows, fill the rest on mount

### DIFF
--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { FaArrowLeft, FaCog, FaPen, FaSort, FaSortDown, FaSortUp, FaSync } from "react-icons/fa";
 import { Link, useParams } from "react-router";
 import useSWR from "swr";
@@ -28,6 +28,10 @@ const LazyNGWordsSettingsModal = lazy(() =>
 
 type SortKey = "responseCount" | "speed" | "creationTime" | "lastUpdated";
 type SortOrder = "asc" | "desc";
+
+// Rows SSR'd before hydration; the rest are rendered client-side on mount to cut
+// single-threaded SSR render cost. 40 covers the fold up to a 4K portrait display.
+const SSR_INITIAL_ROWS = 40;
 
 // In-memory store: survives SPA navigation, resets on hard reload. Never mutated server-side.
 let memorySortKey: SortKey | null = null;
@@ -260,6 +264,18 @@ const ThreadListPage = ({
     );
   }, [sortedThreadList, shouldFilterThread, safeMode, unsafeSet]);
 
+  // Collapsed phase excludes NG (localStorage-only) so SSR and the hydration render match
+  // for every user; safeMode comes from the loader so it is consistent across both.
+  const ssrBaseList = useMemo(
+    () => sortedThreadList.filter((thread) => !(safeMode && unsafeSet.has(thread.id))),
+    [sortedThreadList, safeMode, unsafeSet],
+  );
+
+  const [expanded, setExpanded] = useState(false);
+  useEffect(() => setExpanded(true), []);
+
+  const visibleThreadList = expanded ? filteredThreadList : ssrBaseList.slice(0, SSR_INITIAL_ROWS);
+
   return (
     <div className="relative pt-16 min-h-screen dark:bg-gray-900 dark:text-gray-100">
       {/* Pull-to-refresh indicator */}
@@ -461,7 +477,7 @@ const ThreadListPage = ({
       )}
 
       <div className="flex flex-col lg:grow">
-        {filteredThreadList.map((thread, i) => (
+        {visibleThreadList.map((thread, i) => (
           <div key={thread.id} className="block">
             {i !== 0 && (
               <div className="border-b border-gray-400 dark:border-gray-600 lg:border-none lg:pt-2"></div>


### PR DESCRIPTION
## What

Thread-list SSR rendered **every** row (72+, more at the x9 thread-count peak) synchronously on the single-threaded Node renderer. This SSRs only the first 40 rows and renders the remainder client-side on mount — the same pattern already applied to the thread page.

## Why (measured)

Ingress `request_time` for the list page (client SSR upstream) under load:

| | p50 | p90 | tail |
|---|---|---|---|
| backend `subject.txt` fetch (:8080) | ~20ms | ~40-64ms | ~140ms |
| client SSR list request_time (:5173) | **~450-580ms** | ~700-1050ms | **1.0-1.7s** |

Backend fetch stays ~20ms even at peak, so the 400ms-1.7s is React SSR render + single-thread event-loop queueing — **render/CPU-bound, not fetch-bound**. CPU limit can't be raised, per-row markup is already lean, so reducing rows rendered per request is the effective lever.

## How

- SSR + hydration render `ssrBaseList.slice(0, 40)`; `useEffect` flips to the full `filteredThreadList` on mount.
- **No extra fetch** — the loader already ships every row to the client.
- The collapsed phase uses a **pre-NG list** (sorted + safeMode only, both SSR-consistent), so SSR and the hydration render match for every user. This also removes the pre-existing NG (localStorage-only) hydration mismatch.
- **No minHeight / skeleton** — the settled layout is byte-identical to before. Deferred rows are below the fold on all common devices (CLS stays 0); `N=40` covers the fold up to a 4K portrait display, so pop-in is limited to rare 4K-portrait-at-100%-scaling setups.

## Scope

Single file (`ThreadListPage.tsx`, +18/−2). typecheck / biome / production build all pass.

## Verification plan

Deploy to beta, then compare ingress `/board/` `request_time` by minute (incl. the x9 peak) before/after.