### PR TITLE
perf: prefetch modal chunks so the first click doesn't wait on a fetch

### DIFF
--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -13,15 +13,19 @@ import { usePullToRefresh } from "~/hooks/usePullToRefresh";
 import { useSummarizeEnabled } from "~/hooks/useSummarizeEnabled";
 import { useSummarizerSupported } from "~/hooks/useSummarizer";
 import { parseCookie } from "~/utils/cookie";
+import { intentPrefetch, schedulePrefetch } from "~/utils/prefetch";
 import { getSelectedTextInElement } from "~/utils/selection";
 import { NGContextMenu } from "../components/NGContextMenu";
 import { ThreadSummarizeButton } from "../components/ThreadSummarizeButton";
 import { Button } from "../components/ui/Button";
 import type { Route } from "./+types/ThreadListPage";
 
-const LazyPostThreadModal = lazy(() => import("../components/PostThreadModal"));
+const loadPostThreadModal = () => import("../components/PostThreadModal");
+const loadNGWordsSettingsModal = () => import("../components/NGWordsSettingsModal");
+
+const LazyPostThreadModal = lazy(loadPostThreadModal);
 const LazyNGWordsSettingsModal = lazy(() =>
-  import("../components/NGWordsSettingsModal").then((m) => ({
+  loadNGWordsSettingsModal().then((m) => ({
     default: m.NGWordsSettingsModal,
   })),
 );
@@ -274,6 +278,8 @@ const ThreadListPage = ({
   const [expanded, setExpanded] = useState(false);
   useEffect(() => setExpanded(true), []);
 
+  useEffect(() => schedulePrefetch([loadPostThreadModal, loadNGWordsSettingsModal]), []);
+
   const visibleThreadList = expanded ? filteredThreadList : ssrBaseList.slice(0, SSR_INITIAL_ROWS);
 
   return (
@@ -337,6 +343,7 @@ const ThreadListPage = ({
         <button
           type="button"
           onClick={openNGSettings}
+          {...intentPrefetch(loadNGWordsSettingsModal)}
           className="px-3 py-2 lg:px-4 lg:py-2 mx-1 lg:mx-2 text-sm lg:text-base rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5"
           title="NG設定"
         >
@@ -372,6 +379,7 @@ const ThreadListPage = ({
             hasEverOpenedThread.current = true;
             setCreatingThread(true);
           }}
+          {...intentPrefetch(loadPostThreadModal)}
           className={twMerge("px-4 py-2 lg:px-6 lg:py-3 mx-2", params.boardKey || "hidden")}
         >
           <FaPen className="lg:mr-3" />

--- a/eddist-server/client-v2/app/routes/ThreadPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadPage.tsx
@@ -15,14 +15,18 @@ import {
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useContextMenu } from "~/hooks/useContextMenu";
 import { usePullToRefresh } from "~/hooks/usePullToRefresh";
+import { intentPrefetch, schedulePrefetch } from "~/utils/prefetch";
 import { FloatingNGButton } from "../components/FloatingNGButton";
 import { NGContextMenu } from "../components/NGContextMenu";
 import { Button } from "../components/ui/Button";
 import type { Route } from "./+types/ThreadPage";
 
-const LazyPostResponseModal = lazy(() => import("../components/PostResponseModal"));
+const loadPostResponseModal = () => import("../components/PostResponseModal");
+const loadNGWordsSettingsModal = () => import("../components/NGWordsSettingsModal");
+
+const LazyPostResponseModal = lazy(loadPostResponseModal);
 const LazyNGWordsSettingsModal = lazy(() =>
-  import("../components/NGWordsSettingsModal").then((m) => ({
+  loadNGWordsSettingsModal().then((m) => ({
     default: m.NGWordsSettingsModal,
   })),
 );
@@ -261,6 +265,8 @@ const ThreadPage = ({
     mutate();
   }, [mutate]);
 
+  useEffect(() => schedulePrefetch([loadPostResponseModal, loadNGWordsSettingsModal]), []);
+
   // Find current board
   const currentBoard = boards?.find(
     (board: { board_key: string }) => board.board_key === params.boardKey,
@@ -375,6 +381,7 @@ const ThreadPage = ({
             hasEverOpenedNGSettings.current = true;
             setShowNGSettings(true);
           }}
+          {...intentPrefetch(loadNGWordsSettingsModal)}
           className="px-3 py-2 lg:px-4 lg:py-2 mx-1 text-sm lg:text-base rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
           title="NG設定"
         >
@@ -385,6 +392,7 @@ const ThreadPage = ({
             hasEverOpenedResponse.current = true;
             setCreatingResponse(true);
           }}
+          {...intentPrefetch(loadPostResponseModal)}
           className={twMerge(
             "px-3 py-2 lg:px-6 lg:py-3 lg:mx-2 w-12 h-10 lg:w-35",
             params.boardKey || params.threadKey || "hidden",

--- a/eddist-server/client-v2/app/utils/prefetch.ts
+++ b/eddist-server/client-v2/app/utils/prefetch.ts
@@ -1,0 +1,28 @@
+type ModuleLoader = () => Promise<unknown>;
+
+const warm = (load: ModuleLoader) => {
+  load().catch(() => {});
+};
+
+// Modal chunks are otherwise fetched during the click that opens them, so the
+// Suspense fallback stalls the interaction. Idle time keeps this off the TBT path.
+export const schedulePrefetch = (loaders: readonly ModuleLoader[]) => {
+  const run = () => {
+    for (const load of loaders) warm(load);
+  };
+
+  if (typeof window.requestIdleCallback === "function") {
+    const id = window.requestIdleCallback(run, { timeout: 2000 });
+    return () => window.cancelIdleCallback(id);
+  }
+
+  const id = window.setTimeout(run, 1500);
+  return () => window.clearTimeout(id);
+};
+
+// Covers taps landing before the idle pass: pointerdown/focus precede click.
+export const intentPrefetch = (load: ModuleLoader) => ({
+  onPointerEnter: () => warm(load),
+  onPointerDown: () => warm(load),
+  onFocus: () => warm(load),
+});


### PR DESCRIPTION
## Problem

The write modal (`PostThreadModal` / `PostResponseModal`) and the NG-settings modal are `React.lazy` chunks wrapped in `<Suspense fallback={null}>`. The chunk fetch **started on the click that opened them**, and with a `null` fallback nothing rendered while it loaded — so the button felt unresponsive/blocked.

## Fix

**① Idle prefetch** — warm both modal chunks via `requestIdleCallback` (`setTimeout(1500)` fallback for Safari < 16.4) once the page is interactive. Idle scheduling yields to input, so this stays off the TBT path.

**② Intent prefetch** — the same loader fires on `pointerenter` / `pointerdown` / `focus`, covering taps that land before the idle pass (on touch, `pointerdown` precedes `click`).

The lazy components now reuse named loader functions (`loadPostThreadModal`, …) instead of inline `import()`, so the manual prefetch and `React.lazy` resolve to **one module-registry entry and one chunk** — the second call is a cache hit, never a second fetch.

## Verification

- Modal chunks stay **separate and lazy** — confirmed each route chunk references the modal chunk filename twice (lazy + prefetch, same hash), with no code inlined into the route chunk.
- **`entry.client-I4wjQ2iM.js` is byte-identical to what's deployed** → the eager critical path is untouched, so the recent TBT/FCP gains are preserved.
- Idle payload per route: **~6.4KB gzip** (`NGWordsSettingsModal` 5.40KB + write modal ~0.95KB). The prefetch util itself adds +132B gzip to an already-shared chunk.
- typecheck, biome, and production build all pass (the 2 biome warnings are pre-existing `noDocumentCookie` in `NGWordsSettingsModal`).

## Notes

Not included (available as follow-ups if the click still feels slow): a visible `Suspense` fallback instead of `null`, and stripping flowbite from `NGWordsSettingsModal` — it's the last chunk still pulling it in, and the largest of the prefetched three.