### PR TITLE
ci: pin pnpm via packageManager so minimumReleaseAge is enforced

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -37,7 +37,6 @@ jobs:
         name: Install pnpm
         with:
           run_install: false
-          version: "10.12.1"
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -31,7 +31,6 @@ jobs:
         name: Install pnpm
         with:
           run_install: false
-          version: "10.12.1"
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -72,7 +72,6 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           run_install: false
-          version: "10.12.1"
 
       - name: Setup Node.js & cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
         name: Install pnpm
         with:
           run_install: false
-          version: "10.12.1"
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "packageManager": "pnpm@10.34.5",
   "dependencies": {
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
## Abstract

Makes the existing `minimumReleaseAge` setting actually take effect. No dependency changes, no lockfile changes, no runtime behaviour change.

### The problem

`pnpm-workspace.yaml` has set `minimumReleaseAge: 10080` — a 7-day supply-chain quarantine — for some time. **That option only exists from pnpm 10.16.0, and the pinned pnpm was 10.12.1.** It parsed and did nothing.

An older pnpm does not warn on an unknown setting, so the quarantine looked active while silently doing nothing. This surfaced while preparing the dependency update in #179: a plain `pnpm up -r` pulled `browserslist` published *one hour* earlier.

### The change

- Declare pnpm **10.34.5** (latest 10.x, released 2026-07-10) via `packageManager` in the root `package.json`
- Drop the `version` input from the four workflows

`pnpm/action-setup` errors when the version is declared both ways and the two disagree, so keeping both would make every future bump a five-file change with a hard failure on mismatch. One source of truth avoids that.

`packageManager` is also the half that matters here: CI runs `pnpm install` against a committed lockfile and skips resolution entirely (`Lockfile is up to date, resolution step is skipped`), so the quarantine is enforced at local `pnpm up` time — which is what `packageManager` governs via corepack.

Staying on pnpm 10.x rather than 11 keeps this to a single concern.

### Verification

Against main's unchanged dependencies, under pnpm 10.34.5:
- `pnpm install --frozen-lockfile` is a no-op — the lockfile is not touched
- `biome check` passes for both clients
- `typecheck` passes for both clients
- `eddist-admin-client build` passes

### Note for reviewers

**This PR does not need a beta deploy** — it changes no runtime code. It is split out of #179 deliberately: `issue_comment`-triggered workflows run from the default branch, so #179's beta dispatch fails while main's workflows still carry a conflicting `version` input. Landing this first clears that.

## Associated issue

Split out of #179.

## You need to approve below conditions
- [x] The license of this project may change, and if it does, then you agree to this change for your contributed content (e.g., source code, documentation).
