### PR TITLE
fix: log provider and field on reauth missing-captcha-response failure

### DIFF
--- a/eddist-server/src/services/reauth_service.rs
+++ b/eddist-server/src/services/reauth_service.rs
@@ -64,6 +64,11 @@ impl<T: BbsRepository> AppService<ReAuthServiceInput, ()> for ReAuthService<T> {
                 Some(r) => r.clone(),
                 None => {
                     counter!("reauth_failure", "reason" => "missing_captcha_response").increment(1);
+                    tracing::error!(
+                        provider = %config.provider,
+                        field = %form_field_name,
+                        "captcha response not found in form"
+                    );
                     return Err(BbsPostAuthWithCodeError::CaptchaError(
                         CaptchaLikeError::FailedToVerifyCaptcha,
                     )


### PR DESCRIPTION
## Summary
- Diagnosed a prod incident (2026-08-11 ~14:28-14:31 JST) where a user's re-auth failed despite completing the visible captcha widget in the browser. The `reauth_failure{reason="missing_captcha_response"}` metric confirmed the cause: `ReAuthService` requires a form field for *every* configured provider (not just the visible one), and at least one silent provider likely failed to submit its token client-side.
- `ReAuthService` returned the generic captcha error with no logged detail in this case, unlike `AuthWithCodeService`'s equivalent check, which logs `provider` and `field`.
- Add the same `tracing::error!` call to `reauth_service.rs` so the next occurrence is diagnosable directly from logs instead of inferred from request timing + metrics alone.

## Test plan
- [x] `cargo check` (SQLX_OFFLINE=true) passes with no new errors
- [x] `cargo fmt` clean
- [ ] Deploy and confirm the log line appears with `provider`/`field` on the next `missing_captcha_response` occurrence

