### PR TITLE
fix: use requestSubmit() in tripwire preset to avoid captcha submit race

### DIFF
--- a/eddist-server/src/repositories/captcha_config_repository.rs
+++ b/eddist-server/src/repositories/captcha_config_repository.rs
@@ -70,6 +70,8 @@ fn get_default_widget_config(
             widget_html: String::new(),
             // Intercept form submission manually so token injection is not sensitive
             // to when the async script finishes loading relative to DOMContentLoaded.
+            // Uses requestSubmit() (not submit()) so other async captcha handlers on the
+            // same form still get their submit listener re-invoked instead of being bypassed.
             script_handler: Some(
                 r#"(function() {
   var form = document.getElementById('login-form');
@@ -84,8 +86,8 @@ fn get_default_widget_config(
       input.name = 'tripwire_token';
       input.value = result.token;
       self.appendChild(input);
-      self.submit();
-    }).catch(function() { self.submit(); });
+      self.requestSubmit();
+    }).catch(function() { self.requestSubmit(); });
   });
 })();"#
                     .to_string(),


### PR DESCRIPTION
## Summary
- Root-caused an intermittent `/auth-code` failure: with both `layer3intel_tripwire` and a custom async fingerprinting provider (vercel-token) active, users would occasionally get `missing_captcha_response` or submit with an empty captcha field despite completing everything correctly in the browser.
- Both providers independently intercept the shared login-form's `submit` event, do async work (Tripwire's `run()`, the other provider's fingerprinting call), then call `self.submit()` once done. `form.submit()` bypasses the `submit` event entirely (spec behavior) — so whichever provider's async work resolves first submits the form immediately, orphaning whatever token the other provider hadn't finished writing yet.
- The custom provider's config was already fixed on the admin side to use `requestSubmit()` + a completion guard. This PR applies the matching fix to the `layer3intel_tripwire` preset (`captcha_config_repository.rs`), the other/last hardcoded handler using `self.submit()`.
- `form.requestSubmit()` re-dispatches `submit`, so a still-pending handler gets another chance to run instead of being bypassed; each handler's own "already have a token" guard stops the loop once every provider has filled in its field.

## Test plan
- [x] `cargo check` (SQLX_OFFLINE=true) passes with no new errors
- [x] `cargo fmt` clean
- [ ] Deploy and confirm `/auth-code` failure rate for `missing_captcha_response` / empty vercel-token drops when both providers are active
