### PR TITLE
feat: prepare shared thread metadent NG sync

### DIFF
--- a/eddist-core/src/redis_keys.rs
+++ b/eddist-core/src/redis_keys.rs
@@ -82,6 +82,10 @@ pub fn shared_ng_id_key(board_key: &str, ng_id: &str) -> String {
     format!("shared_ng_id:{board_key}:{ng_id}")
 }
 
+pub fn shared_ng_thread_metadent_key(board_key: &str, metadent: &str) -> String {
+    format!("shared_ng_thread_metadent:{board_key}:{metadent}")
+}
+
 pub fn shared_ng_id_rate_limit_key(token_hash: &str) -> String {
     format!("shared_ng_id:rate_limit:{token_hash}")
 }
@@ -116,6 +120,14 @@ mod tests {
         assert_eq!(
             shared_ng_id_ip_rate_limit_key("2001:db8:85a3:0"),
             "shared_ng_id:ip_rate_limit:2001:db8:85a3:0"
+        );
+    }
+
+    #[test]
+    fn test_shared_ng_thread_metadent_key() {
+        assert_eq!(
+            shared_ng_thread_metadent_key("news", "abcd1234"),
+            "shared_ng_thread_metadent:news:abcd1234"
         );
     }
 }

--- a/eddist-server/client-v2/app/api-client/ng_id.ts
+++ b/eddist-server/client-v2/app/api-client/ng_id.ts
@@ -10,6 +10,21 @@ export const addSharedNgId = async (boardKey: string, ngId: string): Promise<voi
   }
 };
 
+export const addSharedThreadMetadent = async (
+  boardKey: string,
+  metadent: string,
+): Promise<void> => {
+  try {
+    await fetch(`/api/${boardKey}/ng-thread-metadents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ metadent }),
+    });
+  } catch (e) {
+    console.error("[sharedThreadMetadent] add failed", e);
+  }
+};
+
 // Mirrors MAX_NG_IDS_PER_DELETE in routes/ng_id.rs.
 const DELETE_BATCH_SIZE = 200;
 
@@ -25,6 +40,25 @@ export const deleteSharedNgIds = async (boardKey: string, ngIds: string[]): Prom
       });
     } catch (e) {
       console.error("[sharedNgId] delete failed", e);
+    }
+  }
+};
+
+export const deleteSharedThreadMetadents = async (
+  boardKey: string,
+  metadents: string[],
+): Promise<void> => {
+  for (let i = 0; i < metadents.length; i += DELETE_BATCH_SIZE) {
+    const batch = metadents.slice(i, i + DELETE_BATCH_SIZE);
+
+    try {
+      await fetch(`/api/${boardKey}/ng-thread-metadents`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ metadents: batch }),
+      });
+    } catch (e) {
+      console.error("[sharedThreadMetadent] delete failed", e);
     }
   }
 };

--- a/eddist-server/client-v2/app/components/NGContextMenu.tsx
+++ b/eddist-server/client-v2/app/components/NGContextMenu.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
-import { addSharedNgId } from "~/api-client/ng_id";
-import { type NGCategory, useNGWords } from "~/contexts/NGWordsContext";
+import { addSharedNgId, addSharedThreadMetadent } from "~/api-client/ng_id";
+import { type NGCategory, type NGRule, useNGWords } from "~/contexts/NGWordsContext";
 import { useToast } from "~/contexts/ToastContext";
 
 interface NGContextMenuProps {
@@ -127,25 +127,33 @@ export const NGContextMenu = ({
     hideMode?: "hidden" | "collapsed",
   ) => {
     try {
+      // Shared author IDs and thread metadents carry the board key so the settings
+      // dialog can retract the contribution from the corresponding namespace later.
       // A rule holds one board key, so re-sharing a pattern already shared with
       // another board would record a contribution nothing could retract.
-      const existing =
-        category === "response.authorIds"
-          ? config.response.authorIds.find((r) => r.pattern === value && r.matchType === "partial")
-          : undefined;
-      const isSharedNgId =
-        category === "response.authorIds" && (existing?.sharedBoardKey ?? boardKey) === boardKey;
+      const sharedRules: Partial<Record<NGCategory, NGRule[]>> = {
+        "response.authorIds": config.response.authorIds,
+        "thread.authorIds": config.thread.authorIds,
+      };
+      const candidates = sharedRules[category];
+      const existing = candidates?.find((r) => r.pattern === value && r.matchType === "partial");
+      const isSharedTarget =
+        candidates !== undefined && (existing?.sharedBoardKey ?? boardKey) === boardKey;
 
       addRule(category, {
         pattern: value,
         matchType: "partial",
         enabled: true,
         ...(hideMode ? { hideMode } : {}),
-        ...(isSharedNgId ? { sharedBoardKey: boardKey } : {}),
+        ...(isSharedTarget ? { sharedBoardKey: boardKey } : {}),
       });
 
-      if (isSharedNgId) {
-        void addSharedNgId(boardKey, value);
+      if (isSharedTarget) {
+        if (category === "response.authorIds") {
+          void addSharedNgId(boardKey, value);
+        } else {
+          void addSharedThreadMetadent(boardKey, value);
+        }
       }
 
       // Visual feedback

--- a/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
+++ b/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { FaDesktop, FaMoon, FaSun } from "react-icons/fa";
 import { HiInformationCircle } from "react-icons/hi";
 import { useRevalidator } from "react-router";
-import { deleteSharedNgIds } from "~/api-client/ng_id";
+import { deleteSharedNgIds, deleteSharedThreadMetadents } from "~/api-client/ng_id";
 import { useNGWords } from "~/contexts/NGWordsContext";
 import { useTheme } from "~/contexts/ThemeContext";
 import { parseCookie } from "~/utils/cookie";
@@ -150,6 +150,16 @@ export const NGWordsSettingsModal = ({
     removeRule("response.authorIds", ruleId);
   };
 
+  // `thread.authorIds` is the existing client-side name for the metadent parsed
+  // from subject-metadent.txt. Its server contribution has a separate namespace.
+  const removeThreadAuthorId = (ruleId: string) => {
+    const rule = config.thread.authorIds.find((r) => r.id === ruleId);
+    if (rule?.sharedBoardKey) {
+      void deleteSharedThreadMetadents(rule.sharedBoardKey, [rule.pattern]);
+    }
+    removeRule("thread.authorIds", ruleId);
+  };
+
   const handleClearAll = () => {
     if (!window.confirm("すべてのNG設定をクリアしますか？\nこの操作は取り消せません。")) {
       return;
@@ -165,6 +175,18 @@ export const NGWordsSettingsModal = ({
     }
     for (const [boardKey, patterns] of byBoardKey) {
       void deleteSharedNgIds(boardKey, patterns);
+    }
+
+    const metadentsByBoardKey = new Map<string, string[]>();
+    for (const rule of config.thread.authorIds) {
+      if (rule.sharedBoardKey) {
+        const metadents = metadentsByBoardKey.get(rule.sharedBoardKey) ?? [];
+        metadents.push(rule.pattern);
+        metadentsByBoardKey.set(rule.sharedBoardKey, metadents);
+      }
+    }
+    for (const [boardKey, metadents] of metadentsByBoardKey) {
+      void deleteSharedThreadMetadents(boardKey, metadents);
     }
 
     clearAllRules();
@@ -193,7 +215,7 @@ export const NGWordsSettingsModal = ({
                     rules={config.thread.authorIds}
                     onAdd={(rule) => addRule("thread.authorIds", rule)}
                     onUpdate={(id, updates) => updateRule("thread.authorIds", id, updates)}
-                    onRemove={(id) => removeRule("thread.authorIds", id)}
+                    onRemove={removeThreadAuthorId}
                     onToggle={(id) => toggleRule("thread.authorIds", id)}
                     isResponseRule={false}
                   />

--- a/eddist-server/client-v2/app/contexts/NGWordsContext.tsx
+++ b/eddist-server/client-v2/app/contexts/NGWordsContext.tsx
@@ -19,7 +19,7 @@ export interface NGRule {
   matchType: "partial" | "regex";
   enabled: boolean;
   hideMode?: "hidden" | "collapsed";
-  // Set only for rules added from the response-list context menu (shared NG ID).
+  // Set only for rules added from a context menu and synchronized with the server.
   sharedBoardKey?: string;
 }
 

--- a/eddist-server/src/app.rs
+++ b/eddist-server/src/app.rs
@@ -37,7 +37,7 @@ use crate::{
         auth_code::{get_auth_code, post_auth_code},
         bbs_cgi::post_bbs_cgi,
         dat_routing::{get_dat_txt, get_kako_dat_txt},
-        ng_id::{delete_ng_ids, post_ng_id},
+        ng_id::{delete_ng_ids, delete_thread_metadents, post_ng_id, post_thread_metadent},
         notice::{get_latest_notices, get_notice_by_slug, get_notices_paginated},
         re_auth::{get_re_auth, post_re_auth},
         safe_mode::get_unsafe_thread_ids,
@@ -236,6 +236,10 @@ pub fn create_app(app_state: AppState, conn_mgr: redis::aio::ConnectionManager) 
         .route(
             "/api/{boardKey}/ng-ids",
             post(post_ng_id).delete(delete_ng_ids),
+        )
+        .route(
+            "/api/{boardKey}/ng-thread-metadents",
+            post(post_thread_metadent).delete(delete_thread_metadents),
         )
         .route_layer(axum::middleware::from_fn_with_state(
             app_state.clone(),

--- a/eddist-server/src/middleware/ng_id_rate_limit.rs
+++ b/eddist-server/src/middleware/ng_id_rate_limit.rs
@@ -12,9 +12,9 @@ use crate::{
     utils::{get_origin_ip, incr_fixed_window},
 };
 
-const NG_ID_WINDOW_SECS: i64 = 60;
+const SHARED_NG_WINDOW_SECS: i64 = 60;
 
-const NG_ID_THRESHOLD: i64 = 60;
+const SHARED_NG_THRESHOLD: i64 = 60;
 
 pub async fn ng_id_rate_limit_middleware(
     State(state): State<AppState>,
@@ -28,17 +28,17 @@ pub async fn ng_id_rate_limit_middleware(
     let key = shared_ng_id_ip_rate_limit_key(&ip);
 
     let mut redis_conn = state.redis_conn.clone();
-    let count = match incr_fixed_window(&mut redis_conn, &key, NG_ID_WINDOW_SECS).await {
+    let count = match incr_fixed_window(&mut redis_conn, &key, SHARED_NG_WINDOW_SECS).await {
         Ok(count) => count,
         Err(e) => {
-            tracing::error!("Failed to check shared NG ID rate limit for {ip}: {e}");
+            tracing::error!("Failed to check shared NG mutation rate limit for {ip}: {e}");
             return next.run(request).await;
         }
     };
 
-    if count > NG_ID_THRESHOLD {
+    if count > SHARED_NG_THRESHOLD {
         tracing::warn!(
-            "IP {ip} exceeded shared NG ID rate limit ({count} requests within {NG_ID_WINDOW_SECS}s); rejecting with 429"
+            "IP {ip} exceeded shared NG mutation rate limit ({count} requests within {SHARED_NG_WINDOW_SECS}s); rejecting with 429"
         );
         return (StatusCode::TOO_MANY_REQUESTS, "Too Many Requests").into_response();
     }

--- a/eddist-server/src/routes/ng_id.rs
+++ b/eddist-server/src/routes/ng_id.rs
@@ -7,7 +7,7 @@ use axum::{
 use axum_extra::extract::CookieJar;
 use eddist_core::{
     domain::board::validate_board_key,
-    redis_keys::{shared_ng_id_key, shared_ng_id_rate_limit_key},
+    redis_keys::{shared_ng_id_key, shared_ng_id_rate_limit_key, shared_ng_thread_metadent_key},
     utils::to_hex,
 };
 use redis::{AsyncCommands as _, pipe};
@@ -20,14 +20,18 @@ use crate::{
     utils::incr_fixed_window,
 };
 
-const SHARED_NG_ID_TTL_SECS: i64 = 3 * 24 * 60 * 60;
+// Shared NG marks are intentionally short-lived. They represent recent community
+// signals rather than permanent moderation decisions.
+const SHARED_NG_TTL_SECS: i64 = 3 * 24 * 60 * 60;
 
-const MAX_NG_ID_LEN: usize = 64;
+const MAX_SHARED_VALUE_LEN: usize = 64;
+
+const THREAD_METADENT_LEN: usize = 8;
 
 const MAX_NG_IDS_PER_DELETE: usize = 200;
 
-const SHARED_NG_ID_RATE_LIMIT: i64 = 25;
-const SHARED_NG_ID_RATE_LIMIT_WINDOW_SECS: i64 = 24 * 60 * 60;
+const SHARED_NG_RATE_LIMIT: i64 = 25;
+const SHARED_NG_RATE_LIMIT_WINDOW_SECS: i64 = 24 * 60 * 60;
 
 #[derive(Deserialize)]
 pub struct AddNgIdRequest {
@@ -35,8 +39,18 @@ pub struct AddNgIdRequest {
 }
 
 #[derive(Deserialize)]
+pub struct AddThreadMetadentRequest {
+    pub metadent: String,
+}
+
+#[derive(Deserialize)]
 pub struct DeleteNgIdsRequest {
     pub ng_ids: Vec<String>,
+}
+
+#[derive(Deserialize)]
+pub struct DeleteThreadMetadentsRequest {
+    pub metadents: Vec<String>,
 }
 
 fn empty(status: u16) -> Response {
@@ -67,27 +81,95 @@ async fn resolve_contributor_hash(state: &AppState, jar: &CookieJar) -> Result<S
         Ok(Some(token)) => Ok(hash_edge_token(&token.token)),
         Ok(None) => Err(empty(401)),
         Err(e) => {
-            log::error!("Failed to validate edge-token for shared NG ID: {e:?}");
+            log::error!("Failed to validate edge-token for shared NG mark: {e:?}");
             Err(empty(500))
         }
     }
 }
 
-fn is_valid_ng_id(ng_id: &str) -> bool {
-    !ng_id.is_empty()
-        && ng_id.len() <= MAX_NG_ID_LEN
-        && !ng_id.contains(':')
-        && !ng_id.chars().any(|c| c.is_control())
+fn is_valid_shared_value(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_SHARED_VALUE_LEN
+        && !value.contains(':')
+        && !value.chars().any(|c| c.is_control())
 }
 
-async fn within_shared_ng_id_rate_limit(
+fn is_valid_ng_id(ng_id: &str) -> bool {
+    is_valid_shared_value(ng_id)
+}
+
+fn is_valid_thread_metadent(metadent: &str) -> bool {
+    metadent.len() == THREAD_METADENT_LEN
+        && metadent
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '/'))
+}
+
+async fn within_shared_ng_rate_limit(
     conn: &mut redis::aio::ConnectionManager,
     token_hash: &str,
 ) -> redis::RedisResult<bool> {
     let rate_key = shared_ng_id_rate_limit_key(token_hash);
-    let count = incr_fixed_window(conn, &rate_key, SHARED_NG_ID_RATE_LIMIT_WINDOW_SECS).await?;
+    let count = incr_fixed_window(conn, &rate_key, SHARED_NG_RATE_LIMIT_WINDOW_SECS).await?;
 
-    Ok(count <= SHARED_NG_ID_RATE_LIMIT)
+    Ok(count <= SHARED_NG_RATE_LIMIT)
+}
+
+async fn add_shared_value(state: &AppState, jar: &CookieJar, key: String, kind: &str) -> Response {
+    let hash = match resolve_contributor_hash(state, jar).await {
+        Ok(hash) => hash,
+        Err(resp) => return resp,
+    };
+
+    let mut conn = state.redis_conn.clone();
+
+    // The rate-limit key is shared by author IDs and thread metadents, so adding
+    // the second signal type cannot be used to bypass the mutation limit.
+    match within_shared_ng_rate_limit(&mut conn, &hash).await {
+        Ok(true) => {}
+        Ok(false) => return empty(429),
+        Err(e) => {
+            log::error!("Failed to check shared {kind} rate limit: {e:?}");
+            return empty(500);
+        }
+    }
+
+    if let Err(e) = conn.sadd::<_, _, ()>(&key, &hash).await {
+        log::error!("Failed to add shared {kind} to Redis: {e:?}");
+        return empty(500);
+    }
+    if let Err(e) = conn.expire::<_, ()>(&key, SHARED_NG_TTL_SECS).await {
+        log::error!("Failed to set TTL on shared {kind}: {e:?}");
+        return empty(500);
+    }
+
+    empty(204)
+}
+
+async fn remove_shared_values(
+    state: &AppState,
+    jar: &CookieJar,
+    keys: Vec<String>,
+    kind: &str,
+) -> Response {
+    let hash = match resolve_contributor_hash(state, jar).await {
+        Ok(hash) => hash,
+        Err(resp) => return resp,
+    };
+
+    let mut conn = state.redis_conn.clone();
+    let mut pipe = pipe();
+    for key in keys {
+        // SREM is a no-op if the member/key is missing.
+        pipe.srem(key, &hash).ignore();
+    }
+
+    if let Err(e) = pipe.query_async::<()>(&mut conn).await {
+        log::error!("Failed to remove shared {kind} from Redis: {e:?}");
+        return empty(500);
+    }
+
+    empty(204)
 }
 
 pub async fn post_ng_id(
@@ -103,33 +185,8 @@ pub async fn post_ng_id(
         return empty(400);
     }
 
-    let hash = match resolve_contributor_hash(&state, &jar).await {
-        Ok(hash) => hash,
-        Err(resp) => return resp,
-    };
-
     let key = shared_ng_id_key(&board_key, &req.ng_id);
-    let mut conn = state.redis_conn.clone();
-
-    match within_shared_ng_id_rate_limit(&mut conn, &hash).await {
-        Ok(true) => {}
-        Ok(false) => return empty(429),
-        Err(e) => {
-            log::error!("Failed to check shared NG ID rate limit: {e:?}");
-            return empty(500);
-        }
-    }
-
-    if let Err(e) = conn.sadd::<_, _, ()>(&key, &hash).await {
-        log::error!("Failed to add shared NG ID to Redis: {e:?}");
-        return empty(500);
-    }
-    if let Err(e) = conn.expire::<_, ()>(&key, SHARED_NG_ID_TTL_SECS).await {
-        log::error!("Failed to set TTL on shared NG ID: {e:?}");
-        return empty(500);
-    }
-
-    empty(204)
+    add_shared_value(&state, &jar, key, "NG ID").await
 }
 
 pub async fn delete_ng_ids(
@@ -148,25 +205,57 @@ pub async fn delete_ng_ids(
         return empty(400);
     }
 
-    let hash = match resolve_contributor_hash(&state, &jar).await {
-        Ok(hash) => hash,
-        Err(resp) => return resp,
-    };
+    let keys = req
+        .ng_ids
+        .iter()
+        .map(|ng_id| shared_ng_id_key(&board_key, ng_id))
+        .collect();
+    remove_shared_values(&state, &jar, keys, "NG IDs").await
+}
 
-    let mut conn = state.redis_conn.clone();
-
-    let mut pipe = pipe();
-    for ng_id in &req.ng_ids {
-        pipe.srem(shared_ng_id_key(&board_key, ng_id), &hash)
-            .ignore();
+pub async fn post_thread_metadent(
+    State(state): State<AppState>,
+    Path(board_key): Path<String>,
+    jar: CookieJar,
+    Json(req): Json<AddThreadMetadentRequest>,
+) -> Response {
+    if validate_board_key(&board_key).is_err() {
+        return empty(404);
+    }
+    if !is_valid_thread_metadent(&req.metadent) {
+        return empty(400);
     }
 
-    if let Err(e) = pipe.query_async::<()>(&mut conn).await {
-        log::error!("Failed to remove shared NG IDs from Redis: {e:?}");
-        return empty(500);
+    let key = shared_ng_thread_metadent_key(&board_key, &req.metadent);
+    add_shared_value(&state, &jar, key, "thread metadent").await
+}
+
+pub async fn delete_thread_metadents(
+    State(state): State<AppState>,
+    Path(board_key): Path<String>,
+    jar: CookieJar,
+    Json(req): Json<DeleteThreadMetadentsRequest>,
+) -> Response {
+    if validate_board_key(&board_key).is_err() {
+        return empty(404);
+    }
+    if req.metadents.is_empty() || req.metadents.len() > MAX_NG_IDS_PER_DELETE {
+        return empty(400);
+    }
+    if !req
+        .metadents
+        .iter()
+        .all(|metadent| is_valid_thread_metadent(metadent))
+    {
+        return empty(400);
     }
 
-    empty(204)
+    let keys = req
+        .metadents
+        .iter()
+        .map(|metadent| shared_ng_thread_metadent_key(&board_key, metadent))
+        .collect();
+    remove_shared_values(&state, &jar, keys, "thread metadents").await
 }
 
 #[cfg(test)]
@@ -179,5 +268,19 @@ mod probe_tests {
             hash_edge_token("some-edge-token"),
             "2160da207a387b8210efd4de4d0c25645d9cd17f9747fa4e69f23a8bff8874b4"
         );
+    }
+
+    #[test]
+    fn thread_metadent_validation_accepts_generated_format() {
+        assert!(is_valid_thread_metadent("abcd1234"));
+        assert!(is_valid_thread_metadent("+/ab1234"));
+        assert!(is_valid_thread_metadent("abc.1234"));
+    }
+
+    #[test]
+    fn thread_metadent_validation_rejects_other_values() {
+        assert!(!is_valid_thread_metadent("abcd123"));
+        assert!(!is_valid_thread_metadent("abcd:234"));
+        assert!(!is_valid_thread_metadent("abcd 234"));
     }
 }


### PR DESCRIPTION
- Add Redis and API support for shared thread metadents
- Sync thread metadent additions and removals from the client
- Keep the existing thread.authorId client field and shared NG TTL
