### PR TITLE
feat: hash idp sub with issuer before persisting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules/
 .serena/
 
 tmp/
+__pycache__/

--- a/eddist-server/src/domain/user/mod.rs
+++ b/eddist-server/src/domain/user/mod.rs
@@ -21,6 +21,7 @@ pub struct UserIdp {
     pub idp_id: Uuid,
     pub idp_name: String,
     pub idp_display_name: String,
+    /// SHA-256(sub || issuer) instead of raw IdP `sub` claim
     pub idp_sub: String,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,

--- a/eddist-server/src/repositories/user_repository.rs
+++ b/eddist-server/src/repositories/user_repository.rs
@@ -9,6 +9,7 @@ use crate::{
 #[async_trait::async_trait]
 pub trait UserRepository: Send + Sync + 'static {
     async fn get_user_by_id(&self, id: Uuid) -> anyhow::Result<Option<User>>;
+    /// `idp_sub` must already be hashed (see `hash_idp_sub`).
     async fn get_user_by_idp_sub(
         &self,
         idp_name: &str,
@@ -354,5 +355,6 @@ pub struct CreatingUser {
     pub user_id: Uuid,
     pub user_name: String,
     pub idp_id: Uuid,
+    /// Must already be hashed (see `hash_idp_sub`), not the raw IdP `sub` claim.
     pub idp_sub: String,
 }

--- a/eddist-server/src/services/user_authz_idp_callback_service.rs
+++ b/eddist-server/src/services/user_authz_idp_callback_service.rs
@@ -3,6 +3,7 @@ use md5::Digest;
 use openidconnect::{AuthorizationCode, Nonce, PkceCodeVerifier};
 use rand::{RngExt, distr::Alphanumeric};
 use redis::{AsyncCommands, aio::ConnectionManager};
+use sha2::Sha256;
 use sqlx::MySql;
 use uuid::Uuid;
 
@@ -159,12 +160,15 @@ impl<
             )
             .await?;
 
-        let sub = id_token_claims.subject().to_string();
+        let sub_hash = hash_idp_sub(
+            &id_token_claims.subject().to_string(),
+            &id_token_claims.issuer().to_string(),
+        );
         let authed_token_uuid = Uuid::parse_str(&authed_token_id)?;
 
         let user_id = if let Some(u) = self
             .user_repo
-            .get_user_by_idp_sub(&idp.idp_name, &sub)
+            .get_user_by_idp_sub(&idp.idp_name, &sub_hash)
             .await?
         {
             // Already user is registered
@@ -186,7 +190,7 @@ impl<
                         user_id,
                         user_name: user_name_generator(),
                         idp_id: idp.id,
-                        idp_sub: sub,
+                        idp_sub: sub_hash,
                     },
                     tx,
                 )
@@ -254,9 +258,14 @@ impl<
             )
             .await?;
 
+        let sub_hash = hash_idp_sub(
+            &id_token_claims.subject().to_string(),
+            &id_token_claims.issuer().to_string(),
+        );
+
         let user = self
             .user_repo
-            .get_user_by_idp_sub(&idp.idp_name, &id_token_claims.subject().to_string())
+            .get_user_by_idp_sub(&idp.idp_name, &sub_hash)
             .await?;
 
         match user {
@@ -337,6 +346,15 @@ pub struct UserAuthzIdpCallbackServiceOutput {
     pub user_sid: String,
     /// The edge-token to set for the user (used in Register flow)
     pub edge_token: Option<String>,
+}
+
+/// Hashes an IdP `sub` claim with its issuer so the raw value is never persisted.
+fn hash_idp_sub(sub: &str, issuer: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(sub.as_bytes());
+    hasher.update(b"|");
+    hasher.update(issuer.as_bytes());
+    to_hex(hasher.finalize())
 }
 
 fn user_name_generator() -> String {
@@ -528,5 +546,20 @@ mod probe_tests {
         let user_sid = to_hex(hasher.finalize());
         assert_eq!(user_sid.len(), 128);
         assert!(user_sid.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn hash_idp_sub_is_deterministic_and_namespaced_by_issuer() {
+        use super::hash_idp_sub;
+
+        let a = hash_idp_sub("108234567890123456789", "https://accounts.google.com");
+        let b = hash_idp_sub("108234567890123456789", "https://accounts.google.com");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Same sub, different issuer must not collide — sub alone is not a safe key.
+        let c = hash_idp_sub("108234567890123456789", "https://example.auth0.com/");
+        assert_ne!(a, c);
     }
 }

--- a/scripts/backfill_hash_idp_sub.py
+++ b/scripts/backfill_hash_idp_sub.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Backfill user_idp_bindings.idp_sub from plaintext IdP `sub` claims to
+SHA-256(sub || issuer), matching hash_idp_sub() in
+eddist-server/src/services/user_authz_idp_callback_service.rs.
+
+Usage:
+    pip install pymysql requests
+    python3 scripts/backfill_hash_idp_sub.py
+
+By default DATABASE_URL is read from .env (falling back to
+.docker-compose.env) in the repo root; pass --database-url or --env-file to
+override.
+
+Run once with no --apply first to see what would change (dry run is the
+default). Pass --apply to actually write. Safe to re-run: rows whose
+idp_sub already looks like a 64-char lowercase hex hash are skipped, since
+no real IdP `sub` claim takes that exact shape.
+
+The issuer used for hashing is read from each IdP's own OIDC discovery
+document (idps.oidc_config_url -> the `issuer` field), not guessed from the
+URL: OIDC Discovery requires that field to be byte-identical to the `iss`
+claim in tokens issued by that provider, which is exactly what
+id_token_claims.issuer() reads at login time in the Rust code.
+"""
+
+import argparse
+import hashlib
+import re
+import sys
+import uuid
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+try:
+    import pymysql
+    import requests
+except ImportError as e:
+    sys.exit(f"missing dependency: pip install pymysql requests ({e})")
+
+HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_database_url_from_env_file(env_file: Path | None) -> str | None:
+    candidates = [env_file] if env_file else [REPO_ROOT / ".env", REPO_ROOT / ".docker-compose.env"]
+    for path in candidates:
+        if path is None or not path.is_file():
+            continue
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            if key.strip() == "DATABASE_URL":
+                return value.strip().strip('"').strip("'")
+    return None
+
+
+def parse_database_url(url: str) -> dict:
+    parts = urlsplit(url)
+    if parts.scheme != "mysql" or not parts.hostname or not parts.path.lstrip("/"):
+        sys.exit(f"could not parse --database-url: {url!r}")
+    return dict(
+        user=unquote(parts.username) if parts.username else None,
+        password=unquote(parts.password) if parts.password else "",
+        host=parts.hostname,
+        port=parts.port or 3306,
+        database=parts.path.lstrip("/"),
+    )
+
+
+def hash_idp_sub(sub: str, issuer: str) -> str:
+    return hashlib.sha256((sub + "|" + issuer).encode()).hexdigest()
+
+
+def fetch_issuer(oidc_config_url: str) -> str:
+    resp = requests.get(oidc_config_url, timeout=10)
+    resp.raise_for_status()
+    issuer = resp.json().get("issuer")
+    if not issuer:
+        sys.exit(f"discovery document at {oidc_config_url} has no 'issuer' field")
+    return issuer
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--database-url",
+        help="defaults to DATABASE_URL from .env / .docker-compose.env in the repo root",
+    )
+    ap.add_argument(
+        "--env-file",
+        type=Path,
+        help="explicit .env-style file to read DATABASE_URL from",
+    )
+    ap.add_argument("--apply", action="store_true", help="write changes (default: dry run)")
+    args = ap.parse_args()
+
+    database_url = args.database_url or load_database_url_from_env_file(args.env_file)
+    if not database_url:
+        sys.exit(
+            "no --database-url given and DATABASE_URL not found in .env / .docker-compose.env "
+            "(pass --database-url or --env-file explicitly)"
+        )
+
+    conn = pymysql.connect(**parse_database_url(database_url), autocommit=False)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT idp_name, oidc_config_url FROM idps")
+            idps = cur.fetchall()
+
+        issuer_by_idp_name = {}
+        for idp_name, oidc_config_url in idps:
+            issuer = fetch_issuer(oidc_config_url)
+            print(f"idp {idp_name!r}: issuer = {issuer!r} (from {oidc_config_url})")
+            issuer_by_idp_name[idp_name] = issuer
+
+        total = updated = skipped_already_hashed = 0
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT uib.id, uib.idp_sub, idps.idp_name
+                FROM user_idp_bindings uib
+                JOIN idps ON uib.idp_id = idps.id
+                """
+            )
+            rows = cur.fetchall()
+
+        for row_id, idp_sub, idp_name in rows:
+            total += 1
+            if HEX64_RE.match(idp_sub):
+                skipped_already_hashed += 1
+                continue
+
+            issuer = issuer_by_idp_name[idp_name]
+            new_hash = hash_idp_sub(idp_sub, issuer)
+
+            print(f"{uuid.UUID(bytes=row_id)}  [{idp_name}]  {idp_sub!r} -> {new_hash}")
+
+            if args.apply:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE user_idp_bindings SET idp_sub = %s WHERE id = %s",
+                        (new_hash, row_id),
+                    )
+            updated += 1
+
+        if args.apply:
+            conn.commit()
+        else:
+            conn.rollback()
+
+        print(
+            f"\n{'applied' if args.apply else 'dry run'}: "
+            f"{updated}/{total} rows hashed, {skipped_already_hashed} already hashed"
+        )
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Hash the OIDC `sub` claim together with the `iss` claim (SHA-256) before storing/looking it up in user_idp_bindings.idp_sub, so raw subs are never persisted or visible to admins
- Add hash_idp_sub() with a unit test verifying determinism and issuer-namespacing
- Add scripts/backfill_hash_idp_sub.py to hash existing plaintext idp_sub rows in the beta env, deriving each issuer from its OIDC discovery document; defaults to reading DATABASE_URL from .env
