### PR TITLE
fix: return 404 for missing notices

### DIFF
--- a/eddist-server/client-v2/app/api-client/notice.ts
+++ b/eddist-server/client-v2/app/api-client/notice.ts
@@ -55,6 +55,10 @@ export async function fetchNoticeBySlug({
 }): Promise<Notice> {
   const response = await fetch(`${baseUrl}/api/notices/${slug}`);
   if (!response.ok) {
+    if (response.status === 404) {
+      throw new Response("Not Found", { status: 404 });
+    }
+
     throw new Error("Failed to fetch notice");
   }
   return response.json();


### PR DESCRIPTION
Preserve the upstream 404 response for missing notice slugs so React Router renders its 404 boundary instead of returning an SSR 500.
