### PR TITLE
fix: reduce client-v2 modal opening overhead

### DIFF
--- a/eddist-server/client-v2/app/components/NGSettingsLauncher.tsx
+++ b/eddist-server/client-v2/app/components/NGSettingsLauncher.tsx
@@ -1,0 +1,60 @@
+import { type ReactNode, useCallback } from "react";
+import { useToast } from "~/contexts/ToastContext";
+import { useDeferredModal } from "~/hooks/useDeferredModal";
+import type { NGWordsSettingsModal } from "./NGWordsSettingsModal";
+
+const loadNGWordsSettingsModal = () =>
+  import("./NGWordsSettingsModal").then((module) => module.NGWordsSettingsModal);
+
+interface NGSettingsLauncherProps {
+  children: ReactNode;
+  className?: string;
+  enableSafeMode: boolean;
+  summarizerSupported?: boolean;
+  summarizeEnabled?: boolean;
+  onSummarizeEnabledChange?: (enabled: boolean) => void;
+  title?: string;
+}
+
+export const NGSettingsLauncher = ({
+  children,
+  className,
+  title,
+  enableSafeMode,
+  summarizerSupported,
+  summarizeEnabled,
+  onSummarizeEnabledChange,
+}: NGSettingsLauncherProps) => {
+  const { showToast } = useToast();
+  const handleModalLoadError = useCallback(() => {
+    showToast("設定ダイアログの読み込みに失敗しました。再度お試しください。", "error");
+  }, [showToast]);
+  const { Modal, open, openModal, prefetchModal, setOpen } = useDeferredModal<
+    typeof NGWordsSettingsModal
+  >(loadNGWordsSettingsModal, { onOpenError: handleModalLoadError });
+
+  return (
+    <>
+      <button
+        type="button"
+        className={className}
+        title={title}
+        onPointerEnter={prefetchModal}
+        onFocus={prefetchModal}
+        onClick={openModal}
+      >
+        {children}
+      </button>
+      {Modal ? (
+        <Modal
+          open={open}
+          setOpen={setOpen}
+          enableSafeMode={enableSafeMode}
+          summarizerSupported={summarizerSupported}
+          summarizeEnabled={summarizeEnabled}
+          onSummarizeEnabledChange={onSummarizeEnabledChange}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/eddist-server/client-v2/app/components/PostResponseLauncher.tsx
+++ b/eddist-server/client-v2/app/components/PostResponseLauncher.tsx
@@ -1,0 +1,53 @@
+import { type ReactNode, useCallback } from "react";
+import { useToast } from "~/contexts/ToastContext";
+import { useDeferredModal } from "~/hooks/useDeferredModal";
+import type PostResponseModal from "./PostResponseModal";
+import { Button } from "./ui/Button";
+
+const loadPostResponseModal = () => import("./PostResponseModal").then((module) => module.default);
+
+interface PostResponseLauncherProps {
+  children: ReactNode;
+  className?: string;
+  boardKey: string;
+  threadKey: string;
+  refetchThread: () => Promise<unknown>;
+}
+
+export const PostResponseLauncher = ({
+  children,
+  className,
+  boardKey,
+  threadKey,
+  refetchThread,
+}: PostResponseLauncherProps) => {
+  const { showToast } = useToast();
+  const handleModalLoadError = useCallback(() => {
+    showToast("書き込みダイアログの読み込みに失敗しました。再度お試しください。", "error");
+  }, [showToast]);
+  const { Modal, open, openModal, prefetchModal, setOpen } = useDeferredModal<
+    typeof PostResponseModal
+  >(loadPostResponseModal, { onOpenError: handleModalLoadError });
+
+  return (
+    <>
+      <Button
+        onPointerEnter={prefetchModal}
+        onFocus={prefetchModal}
+        onClick={openModal}
+        className={className}
+      >
+        {children}
+      </Button>
+      {Modal ? (
+        <Modal
+          open={open}
+          setOpen={setOpen}
+          boardKey={boardKey}
+          threadKey={threadKey}
+          refetchThread={refetchThread}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/eddist-server/client-v2/app/components/PostThreadLauncher.tsx
+++ b/eddist-server/client-v2/app/components/PostThreadLauncher.tsx
@@ -1,0 +1,50 @@
+import { type ReactNode, useCallback } from "react";
+import { useToast } from "~/contexts/ToastContext";
+import { useDeferredModal } from "~/hooks/useDeferredModal";
+import type PostThreadModal from "./PostThreadModal";
+import { Button } from "./ui/Button";
+
+const loadPostThreadModal = () => import("./PostThreadModal").then((module) => module.default);
+
+interface PostThreadLauncherProps {
+  children: ReactNode;
+  className?: string;
+  boardKey: string;
+  refetchThreadList: () => Promise<unknown>;
+}
+
+export const PostThreadLauncher = ({
+  children,
+  className,
+  boardKey,
+  refetchThreadList,
+}: PostThreadLauncherProps) => {
+  const { showToast } = useToast();
+  const handleModalLoadError = useCallback(() => {
+    showToast("スレッド作成ダイアログの読み込みに失敗しました。再度お試しください。", "error");
+  }, [showToast]);
+  const { Modal, open, openModal, prefetchModal, setOpen } = useDeferredModal<
+    typeof PostThreadModal
+  >(loadPostThreadModal, { onOpenError: handleModalLoadError });
+
+  return (
+    <>
+      <Button
+        onPointerEnter={prefetchModal}
+        onFocus={prefetchModal}
+        onClick={openModal}
+        className={className}
+      >
+        {children}
+      </Button>
+      {Modal ? (
+        <Modal
+          open={open}
+          setOpen={setOpen}
+          boardKey={boardKey}
+          refetchThreadList={refetchThreadList}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/eddist-server/client-v2/app/hooks/useDeferredModal.ts
+++ b/eddist-server/client-v2/app/hooks/useDeferredModal.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type ModalLoader<T> = () => Promise<T>;
+type AnyModalLoader = () => Promise<unknown>;
+
+interface DeferredModalOptions {
+  onOpenError?: (error: unknown) => void;
+}
+
+const modalComponentPromises = new Map<AnyModalLoader, Promise<unknown>>();
+const resolvedModalComponents = new Map<AnyModalLoader, unknown>();
+
+const loadModalComponent = <T>(loader: ModalLoader<T>) => {
+  const cachedPromise = modalComponentPromises.get(loader);
+  if (cachedPromise) return cachedPromise as Promise<T>;
+
+  const promise = loader()
+    .then((component) => {
+      resolvedModalComponents.set(loader, component);
+      return component;
+    })
+    .catch((error) => {
+      modalComponentPromises.delete(loader);
+      throw error;
+    });
+  modalComponentPromises.set(loader, promise);
+  return promise;
+};
+
+const getResolvedModalComponent = <T>(loader: ModalLoader<T>) => {
+  return resolvedModalComponents.get(loader) as T | undefined;
+};
+
+export const useDeferredModal = <T>(
+  loader: ModalLoader<T>,
+  { onOpenError }: DeferredModalOptions = {},
+) => {
+  const [component, setComponent] = useState<T | null>(
+    () => getResolvedModalComponent(loader) ?? null,
+  );
+  const [open, setOpen] = useState(false);
+  const mountedRef = useRef(false);
+  const hasOpenedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const resolveComponent = useCallback(() => {
+    return loadModalComponent(loader).then((loadedComponent) => {
+      if (mountedRef.current) setComponent(() => loadedComponent);
+      return loadedComponent;
+    });
+  }, [loader]);
+
+  const prefetchModal = useCallback(() => {
+    void resolveComponent().catch(() => undefined);
+  }, [resolveComponent]);
+
+  const openModal = useCallback(() => {
+    hasOpenedRef.current = true;
+    if (component) {
+      setOpen(true);
+      return;
+    }
+
+    void resolveComponent()
+      .then(() => {
+        if (mountedRef.current) setOpen(true);
+      })
+      .catch((error) => {
+        if (mountedRef.current) onOpenError?.(error);
+      });
+  }, [component, onOpenError, resolveComponent]);
+
+  const Modal = hasOpenedRef.current ? component : null;
+  return { Modal, open, openModal, prefetchModal, setOpen };
+};

--- a/eddist-server/client-v2/app/routes/ThreadListPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadListPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FaArrowLeft, FaCog, FaPen, FaSort, FaSortDown, FaSortUp, FaSync } from "react-icons/fa";
 import { Link, useParams } from "react-router";
 import useSWR from "swr";
@@ -16,16 +16,10 @@ import { useSummarizerSupported } from "~/hooks/useSummarizer";
 import { parseCookie } from "~/utils/cookie";
 import { getSelectedTextInElement } from "~/utils/selection";
 import { NGContextMenu } from "../components/NGContextMenu";
+import { NGSettingsLauncher } from "../components/NGSettingsLauncher";
+import { PostThreadLauncher } from "../components/PostThreadLauncher";
 import { ThreadSummarizeButton } from "../components/ThreadSummarizeButton";
-import { Button } from "../components/ui/Button";
 import type { Route } from "./+types/ThreadListPage";
-
-const LazyPostThreadModal = lazy(() => import("../components/PostThreadModal"));
-const LazyNGWordsSettingsModal = lazy(() =>
-  import("../components/NGWordsSettingsModal").then((m) => ({
-    default: m.NGWordsSettingsModal,
-  })),
-);
 
 type SortKey = "responseCount" | "speed" | "creationTime" | "lastUpdated";
 type SortOrder = "asc" | "desc";
@@ -186,13 +180,9 @@ const ThreadListPage = ({
     },
   );
 
-  const [creatingThread, setCreatingThread] = useState(false);
   const { sortKey, sortOrder, setSortKey, setSortOrder } = useMemorySort();
   const [showSortControls, setShowSortControls] = useState(false);
-  const [showNGSettings, setShowNGSettings] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const hasEverOpenedThread = useRef(false);
-  const hasEverOpenedNGSettings = useRef(false);
 
   const { shouldFilterThread, setSharedNgList } = useNGWords();
   useEffect(() => {
@@ -226,11 +216,6 @@ const ThreadListPage = ({
     enabled: true,
     scrollTarget: "window",
   });
-
-  const openNGSettings = () => {
-    hasEverOpenedNGSettings.current = true;
-    setShowNGSettings(true);
-  };
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -346,14 +331,16 @@ const ThreadListPage = ({
             className={twMerge("w-4 h-4", (isRefreshing || isPullRefreshing) && "animate-spin")}
           />
         </button>
-        <button
-          type="button"
-          onClick={openNGSettings}
-          className="px-3 py-2 lg:px-4 lg:py-2 mx-1 lg:mx-2 text-sm lg:text-base rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5"
+        <NGSettingsLauncher
+          enableSafeMode={enableSafeMode}
+          summarizerSupported={summarizerSupported}
+          summarizeEnabled={summarizeEnabled}
+          onSummarizeEnabledChange={setSummarizeEnabled}
           title="NG設定"
+          className="px-3 py-2 lg:px-4 lg:py-2 mx-1 lg:mx-2 text-sm lg:text-base rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-1.5"
         >
           <FaCog className="w-4 h-4" />
-        </button>
+        </NGSettingsLauncher>
         <button
           type="button"
           onClick={() => setShowSortControls(!showSortControls)}
@@ -379,41 +366,15 @@ const ThreadListPage = ({
               : "ソート順"}
           </span>
         </button>
-        <Button
-          onClick={() => {
-            hasEverOpenedThread.current = true;
-            setCreatingThread(true);
-          }}
+        <PostThreadLauncher
+          boardKey={params.boardKey ?? ""}
+          refetchThreadList={mutate}
           className={twMerge("px-4 py-2 lg:px-6 lg:py-3 mx-2", params.boardKey || "hidden")}
         >
           <FaPen className="lg:mr-3" />
           <span className="lg:block hidden">スレッド作成</span>
-        </Button>
-
-        {hasEverOpenedNGSettings.current && (
-          <Suspense fallback={null}>
-            <LazyNGWordsSettingsModal
-              open={showNGSettings}
-              setOpen={setShowNGSettings}
-              enableSafeMode={enableSafeMode}
-              summarizerSupported={summarizerSupported}
-              summarizeEnabled={summarizeEnabled}
-              onSummarizeEnabledChange={setSummarizeEnabled}
-            />
-          </Suspense>
-        )}
+        </PostThreadLauncher>
       </header>
-
-      {hasEverOpenedThread.current && (
-        <Suspense fallback={null}>
-          <LazyPostThreadModal
-            boardKey={params.boardKey ?? ""}
-            open={creatingThread}
-            setOpen={setCreatingThread}
-            refetchThreadList={mutate}
-          />
-        </Suspense>
-      )}
 
       {showSortControls && (
         <div className="bg-white dark:bg-gray-900 border-b border-gray-300 dark:border-gray-700 p-3 flex flex-wrap gap-2 items-center">

--- a/eddist-server/client-v2/app/routes/ThreadPage.tsx
+++ b/eddist-server/client-v2/app/routes/ThreadPage.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { FaArrowLeft, FaCog, FaPen, FaSync } from "react-icons/fa";
 import { data, Link, useParams } from "react-router";
 import useSWR from "swr";
@@ -18,15 +18,9 @@ import { useContextMenu } from "~/hooks/useContextMenu";
 import { usePullToRefresh } from "~/hooks/usePullToRefresh";
 import { FloatingNGButton } from "../components/FloatingNGButton";
 import { NGContextMenu } from "../components/NGContextMenu";
-import { Button } from "../components/ui/Button";
+import { NGSettingsLauncher } from "../components/NGSettingsLauncher";
+import { PostResponseLauncher } from "../components/PostResponseLauncher";
 import type { Route } from "./+types/ThreadPage";
-
-const LazyPostResponseModal = lazy(() => import("../components/PostResponseModal"));
-const LazyNGWordsSettingsModal = lazy(() =>
-  import("../components/NGWordsSettingsModal").then((m) => ({
-    default: m.NGWordsSettingsModal,
-  })),
-);
 
 // SSR/hydrate this many leading res; the client fills the rest by refetching the
 // full .dat on mount. Kept small so the hydration payload is a bounded prefix, not
@@ -159,8 +153,6 @@ const ThreadPage = ({
 
   const [popups, setPopups] = useState<Popup[]>([]);
   const popupCounter = useRef(0);
-  const hasEverOpenedResponse = useRef(false);
-  const hasEverOpenedNGSettings = useRef(false);
 
   useEffect(() => {
     const htmlEl = document.documentElement;
@@ -220,8 +212,6 @@ const ThreadPage = ({
     ]);
   };
 
-  const [creatingResponse, setCreatingResponse] = useState(false);
-  const [showNGSettings, setShowNGSettings] = useState(false);
   const [expandedNGPosts, setExpandedNGPosts] = useState<Set<number>>(new Set());
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -376,22 +366,17 @@ const ThreadPage = ({
             className={twMerge("w-4 h-4", (isRefreshing || isPullRefreshing) && "animate-spin")}
           />
         </button>
-        <button
-          type="button"
-          onClick={() => {
-            hasEverOpenedNGSettings.current = true;
-            setShowNGSettings(true);
-          }}
-          className="px-3 py-2 lg:px-4 lg:py-2 mx-1 text-sm lg:text-base rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        <NGSettingsLauncher
+          enableSafeMode={enableSafeMode}
           title="NG設定"
+          className="px-3 py-2 lg:px-4 lg:py-2 mx-1 text-sm lg:text-base rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
         >
           <FaCog className="w-4 h-4" />
-        </button>
-        <Button
-          onClick={() => {
-            hasEverOpenedResponse.current = true;
-            setCreatingResponse(true);
-          }}
+        </NGSettingsLauncher>
+        <PostResponseLauncher
+          boardKey={params.boardKey ?? ""}
+          threadKey={params.threadKey ?? ""}
+          refetchThread={mutate}
           className={twMerge(
             "px-3 py-2 lg:px-6 lg:py-3 lg:mx-2 w-12 h-10 lg:w-35",
             params.boardKey || params.threadKey || "hidden",
@@ -399,30 +384,8 @@ const ThreadPage = ({
         >
           <FaPen className="lg:mr-3" />
           <span className="lg:block hidden">書き込み</span>
-        </Button>
-
-        {hasEverOpenedNGSettings.current && (
-          <Suspense fallback={null}>
-            <LazyNGWordsSettingsModal
-              open={showNGSettings}
-              setOpen={setShowNGSettings}
-              enableSafeMode={enableSafeMode}
-            />
-          </Suspense>
-        )}
+        </PostResponseLauncher>
       </header>
-
-      {hasEverOpenedResponse.current && (
-        <Suspense fallback={null}>
-          <LazyPostResponseModal
-            open={creatingResponse}
-            setOpen={setCreatingResponse}
-            boardKey={params.boardKey ?? ""}
-            threadKey={params.threadKey ?? ""}
-            refetchThread={mutate}
-          />
-        </Suspense>
-      )}
 
       <main className="grow pt-18 lg:pt-16">
         <div className="max-w-7xl mx-auto">


### PR DESCRIPTION
- Prefetch modal chunks only on pointer or focus intent.
- Keep Flowbite and react-hook-form modal implementations out of the initial route path.
- Surface dynamic chunk failures through the existing toast notifications.
- Extract modal-specific launchers from the shared deferred-modal hook.

