### PR TITLE
fix: hide clear-all button on non-NG settings tab

### DIFF
--- a/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
+++ b/eddist-server/client-v2/app/components/NGWordsSettingsModal.tsx
@@ -233,6 +233,7 @@ export const NGWordsSettingsModal = ({
   onSummarizeEnabledChange,
 }: NGWordsSettingsModalProps) => {
   const { config, addRule, updateRule, removeRule, toggleRule, clearAllRules } = useNGWords();
+  const [activeTab, setActiveTab] = useState("thread");
 
   const removeResponseAuthorId = (ruleId: string) => {
     const rule = config.response.authorIds.find((r) => r.id === ruleId);
@@ -296,6 +297,7 @@ export const NGWordsSettingsModal = ({
       </ModalHeader>
       <ModalBody className="pb-0">
         <Tabs
+          onTabChange={setActiveTab}
           tabs={[
             {
               id: "thread",
@@ -374,9 +376,13 @@ export const NGWordsSettingsModal = ({
         />
       </ModalBody>
       <ModalFooter className="flex justify-between mt-6 border-t border-gray-200 dark:border-gray-700">
-        <Button color="gray" onClick={handleClearAll}>
-          すべてクリア
-        </Button>
+        {activeTab === "thread" || activeTab === "response" ? (
+          <Button color="gray" onClick={handleClearAll}>
+            すべてクリア
+          </Button>
+        ) : (
+          <div />
+        )}
         <Button onClick={() => setOpen(false)}>閉じる</Button>
       </ModalFooter>
     </Modal>

--- a/eddist-server/client-v2/app/components/Tabs.tsx
+++ b/eddist-server/client-v2/app/components/Tabs.tsx
@@ -10,11 +10,17 @@ export interface Tab {
 interface TabsProps {
   tabs: Tab[];
   defaultTab?: string;
+  onTabChange?: (tabId: string) => void;
 }
 
-export const Tabs = ({ tabs, defaultTab }: TabsProps) => {
+export const Tabs = ({ tabs, defaultTab, onTabChange }: TabsProps) => {
   const [activeTab, setActiveTab] = useState(defaultTab ?? tabs[0]?.id);
   const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  const selectTab = (tabId: string) => {
+    setActiveTab(tabId);
+    onTabChange?.(tabId);
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent, currentIndex: number) => {
     let newIndex = currentIndex;
@@ -36,7 +42,7 @@ export const Tabs = ({ tabs, defaultTab }: TabsProps) => {
     }
 
     const newTab = tabs[newIndex];
-    setActiveTab(newTab.id);
+    selectTab(newTab.id);
     tabRefs.current.get(newTab.id)?.focus();
   };
 
@@ -58,7 +64,7 @@ export const Tabs = ({ tabs, defaultTab }: TabsProps) => {
               id={`tab-${tab.id}`}
               tabIndex={isActive ? 0 : -1}
               type="button"
-              onClick={() => setActiveTab(tab.id)}
+              onClick={() => selectTab(tab.id)}
               onKeyDown={(e) => handleKeyDown(e, index)}
               className={twMerge(
                 "px-4 py-2 font-medium transition-colors",


### PR DESCRIPTION
- NGWordsSettingsModal's footer rendered the "すべてクリア" button unconditionally, outside the Tabs component, so it showed even on the "その他" (Other) tab where it has no effect
- Add onTabChange to Tabs so the parent can track the active tab
- Only render the clear-all button on the "スレッドNG"/"レスNG" tabs