### PR TITLE
fix: exclude mass-anchor posts from back-reference tracking

### DIFF
--- a/eddist-server/client-v2/app/api-client/thread.ts
+++ b/eddist-server/client-v2/app/api-client/thread.ts
@@ -256,6 +256,9 @@ export const convertThreadTextToResponseList = (text: string) => {
   };
 };
 
+// Back-reference tracking only; anchors are still linked past this count.
+const MAX_ANCHORS_PER_BODY = 10;
+
 const buildAnchorPartedBody = (body: string): [BodyAnchorPart[], number[]] => {
   const refs = [];
   const parts = [];
@@ -280,5 +283,5 @@ const buildAnchorPartedBody = (body: string): [BodyAnchorPart[], number[]] => {
     parts.push({ text: body.slice(lastIndex), isMatch: false });
   }
 
-  return [parts, refs];
+  return [parts, refs.length >= MAX_ANCHORS_PER_BODY ? [] : refs];
 };


### PR DESCRIPTION
- Skip refs collection for bodies with 10 or more >>n anchors in buildAnchorPartedBody, so they no longer appear in every named response's reply list
- Keep anchors linked and poppable as before; only the back-reference calculation is affected
