### PR TITLE
refactor(admin): migrate thread repository to SeaORM

### DIFF
--- a/eddist-admin/src/entity/archived_thread.rs
+++ b/eddist-admin/src/entity/archived_thread.rs
@@ -1,0 +1,25 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "archived_threads")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub board_id: Uuid,
+    pub thread_number: i64,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub last_modified_at: DateTime,
+    pub sage_last_modified_at: DateTime,
+    pub title: String,
+    pub authed_token_id: Uuid,
+    pub metadent: String,
+    pub response_count: i32,
+    pub no_pool: bool,
+    pub active: bool,
+    pub archived: bool,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/eddist-admin/src/entity/mod.rs
+++ b/eddist-admin/src/entity/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod archived_thread;
 pub(crate) mod authed_token;
 pub(crate) mod board;
 pub(crate) mod board_cap;

--- a/eddist-admin/src/main.rs
+++ b/eddist-admin/src/main.rs
@@ -265,7 +265,7 @@ async fn main() {
     let service_container = services::AppServiceContainer::new(
         ContentRepos {
             board: Arc::new(AdminBoardRepositoryImpl::new(orm_db.clone())),
-            thread: Arc::new(AdminThreadRepositoryImpl::new(pool.clone())),
+            thread: Arc::new(AdminThreadRepositoryImpl::new(orm_db.clone())),
             response: Arc::new(AdminResponseRepositoryImpl::new(pool.clone())),
             archive: Arc::new(AdminArchiveRepositoryImpl::new(s3_client, s3_bucket_name)),
         },

--- a/eddist-admin/src/repository/admin_bbs_repository.rs
+++ b/eddist-admin/src/repository/admin_bbs_repository.rs
@@ -1,22 +1,5 @@
-use chrono::Utc;
 use eddist_core::domain::client_info::ClientInfo;
-use sqlx::{FromRow, types::Json};
-
-#[derive(Debug, FromRow)]
-pub struct SelectionThread {
-    pub id: Vec<u8>,
-    pub board_id: Vec<u8>,
-    pub thread_number: i64,
-    pub last_modified_at: chrono::DateTime<Utc>,
-    pub sage_last_modified_at: chrono::DateTime<Utc>,
-    pub title: String,
-    pub authed_token_id: Vec<u8>,
-    pub metadent: String,
-    pub response_count: i32,
-    pub no_pool: bool,
-    pub archived: bool,
-    pub active: bool,
-}
+use sqlx::types::Json;
 
 #[derive(Debug)]
 pub struct SelectionRes {

--- a/eddist-admin/src/repository/admin_thread_repository.rs
+++ b/eddist-admin/src/repository/admin_thread_repository.rs
@@ -1,11 +1,11 @@
-use crate::transaction_repository;
-use chrono::Utc;
-use sqlx::MySqlPool;
-use uuid::Uuid;
-
+use crate::entity::{archived_thread, board, thread};
 use crate::models::Thread;
-
-use super::admin_bbs_repository::SelectionThread;
+use sea_orm::sea_query::Expr;
+use sea_orm::{
+    ColumnTrait, DatabaseConnection, EntityTrait, FromQueryResult, QueryFilter, QueryOrder,
+    QuerySelect,
+};
+use uuid::Uuid;
 
 #[async_trait::async_trait]
 pub trait AdminThreadRepository: Send + Sync {
@@ -23,7 +23,10 @@ pub trait AdminThreadRepository: Send + Sync {
         &self,
         board_key: &str,
         keyword: Option<&str>,
-        range: (Option<chrono::DateTime<Utc>>, Option<chrono::DateTime<Utc>>),
+        range: (
+            Option<chrono::DateTime<chrono::Utc>>,
+            Option<chrono::DateTime<chrono::Utc>>,
+        ),
         page: u64,
         limit: u64,
     ) -> anyhow::Result<Vec<Thread>>;
@@ -32,29 +35,77 @@ pub trait AdminThreadRepository: Send + Sync {
 }
 
 #[derive(Clone)]
-pub struct AdminThreadRepositoryImpl(pub(crate) MySqlPool);
+pub struct AdminThreadRepositoryImpl(pub(crate) DatabaseConnection);
 
 impl AdminThreadRepositoryImpl {
-    pub fn new(pool: MySqlPool) -> Self {
-        Self(pool)
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self(db)
+    }
+
+    async fn board_id_by_key(&self, board_key: &str) -> anyhow::Result<Option<Uuid>> {
+        Ok(board::Entity::find()
+            .filter(board::Column::BoardKey.eq(board_key))
+            .one(&self.0)
+            .await?
+            .map(|model| model.id))
     }
 }
 
-fn selection_thread_to_thread(thread: SelectionThread) -> Thread {
-    Thread {
-        id: Uuid::from_slice(&thread.id).unwrap(),
-        board_id: Uuid::from_slice(&thread.board_id).unwrap(),
-        thread_number: thread.thread_number as u64,
-        last_modified: thread.last_modified_at,
-        sage_last_modified: thread.sage_last_modified_at,
-        title: thread.title,
-        authed_token_id: Uuid::from_slice(&thread.authed_token_id).unwrap(),
-        metadent: thread.metadent,
-        response_count: thread.response_count as u32,
-        no_pool: thread.no_pool,
-        archived: thread.archived,
-        active: thread.active,
-    }
+#[derive(Debug, FromQueryResult)]
+struct ThreadId {
+    id: Uuid,
+}
+
+fn parse_thread_numbers(thread_numbers: Option<Vec<u64>>) -> anyhow::Result<Option<Vec<i64>>> {
+    thread_numbers
+        .map(|values| {
+            values
+                .into_iter()
+                .map(|value| {
+                    i64::try_from(value)
+                        .map_err(|_| anyhow::anyhow!("thread number is too large: {value}"))
+                })
+                .collect()
+        })
+        .transpose()
+}
+
+fn into_thread(model: thread::Model) -> anyhow::Result<Thread> {
+    Ok(Thread {
+        id: model.id,
+        board_id: model.board_id,
+        thread_number: u64::try_from(model.thread_number)
+            .map_err(|_| anyhow::anyhow!("negative thread number: {}", model.thread_number))?,
+        last_modified: model.last_modified_at.and_utc(),
+        sage_last_modified: model.sage_last_modified_at.and_utc(),
+        title: model.title,
+        authed_token_id: model.authed_token_id,
+        metadent: model.metadent,
+        response_count: u32::try_from(model.response_count)
+            .map_err(|_| anyhow::anyhow!("negative response count: {}", model.response_count))?,
+        no_pool: model.no_pool,
+        archived: model.archived,
+        active: model.active,
+    })
+}
+
+fn into_archived_thread(model: archived_thread::Model) -> anyhow::Result<Thread> {
+    Ok(Thread {
+        id: model.id,
+        board_id: model.board_id,
+        thread_number: u64::try_from(model.thread_number)
+            .map_err(|_| anyhow::anyhow!("negative thread number: {}", model.thread_number))?,
+        last_modified: model.last_modified_at.and_utc(),
+        sage_last_modified: model.sage_last_modified_at.and_utc(),
+        title: model.title,
+        authed_token_id: model.authed_token_id,
+        metadent: model.metadent,
+        response_count: u32::try_from(model.response_count)
+            .map_err(|_| anyhow::anyhow!("negative response count: {}", model.response_count))?,
+        no_pool: model.no_pool,
+        archived: model.archived,
+        active: model.active,
+    })
 }
 
 #[async_trait::async_trait]
@@ -64,57 +115,21 @@ impl AdminThreadRepository for AdminThreadRepositoryImpl {
         board_key: &str,
         thread_numbers: Option<Vec<u64>>,
     ) -> anyhow::Result<Vec<Thread>> {
-        let pool = &self.0;
-
-        let thread_numbers_where = if let Some(thread_numbers) = &thread_numbers {
-            let mut initial = "AND thread_number IN (".to_string();
-            initial.push_str(
-                &thread_numbers
-                    .iter()
-                    .map(|_| "?")
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            );
-            initial.push(')');
-            initial
-        } else {
-            "".to_string()
+        let Some(board_id) = self.board_id_by_key(board_key).await? else {
+            return Ok(Vec::new());
         };
 
-        let query = format!(
-            r#"
-            SELECT
-                *
-            FROM
-                threads
-            WHERE
-                board_id = (
-                    SELECT
-                        id
-                    FROM
-                        boards
-                    WHERE
-                        board_key = ?
-                )
-            {thread_numbers_where}
-            "#
-        );
-
-        // Dynamic part is only fixed clause fragments / `?` counts; values are bound below.
-        let mut query = sqlx::query_as::<_, SelectionThread>(sqlx::AssertSqlSafe(query));
-
-        query = query.bind(board_key);
-        if let Some(thread_numbers) = &thread_numbers {
-            for thread_number in thread_numbers {
-                query = query.bind(thread_number);
-            }
+        let mut query = thread::Entity::find().filter(thread::Column::BoardId.eq(board_id));
+        if let Some(thread_numbers) = parse_thread_numbers(thread_numbers)? {
+            query = query.filter(thread::Column::ThreadNumber.is_in(thread_numbers));
         }
 
-        let selected_threads = query.fetch_all(pool).await?;
-        Ok(selected_threads
+        query
+            .all(&self.0)
+            .await?
             .into_iter()
-            .map(selection_thread_to_thread)
-            .collect())
+            .map(into_thread)
+            .collect()
     }
 
     async fn get_archived_threads_by_thread_id(
@@ -122,135 +137,91 @@ impl AdminThreadRepository for AdminThreadRepositoryImpl {
         board_key: &str,
         thread_numbers: Option<Vec<u64>>,
     ) -> anyhow::Result<Vec<Thread>> {
-        let pool = &self.0;
-
-        let thread_numbers_where = if let Some(thread_numbers) = &thread_numbers {
-            let mut initial = "AND thread_number IN (".to_string();
-            initial.push_str(
-                &thread_numbers
-                    .iter()
-                    .map(|_| "?")
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            );
-            initial.push(')');
-            initial
-        } else {
-            "".to_string()
+        let Some(board_id) = self.board_id_by_key(board_key).await? else {
+            return Ok(Vec::new());
         };
 
-        let query = format!(
-            r#"
-            SELECT
-                *
-            FROM
-                archived_threads
-            WHERE
-                board_id = (
-                    SELECT
-                        id
-                    FROM
-                        boards
-                    WHERE
-                        board_key = ?
-                )
-            {thread_numbers_where}
-            "#
-        );
-
-        // Dynamic part is only fixed clause fragments / `?` counts; values are bound below.
-        let mut query = sqlx::query_as::<_, SelectionThread>(sqlx::AssertSqlSafe(query));
-
-        query = query.bind(board_key);
-        if let Some(thread_numbers) = &thread_numbers {
-            for thread_number in thread_numbers {
-                query = query.bind(thread_number);
-            }
+        let mut query =
+            archived_thread::Entity::find().filter(archived_thread::Column::BoardId.eq(board_id));
+        if let Some(thread_numbers) = parse_thread_numbers(thread_numbers)? {
+            query = query.filter(archived_thread::Column::ThreadNumber.is_in(thread_numbers));
         }
 
-        let selected_threads = query.fetch_all(pool).await?;
-        Ok(selected_threads
+        query
+            .all(&self.0)
+            .await?
             .into_iter()
-            .map(selection_thread_to_thread)
-            .collect())
+            .map(into_archived_thread)
+            .collect()
     }
 
     async fn get_archived_threads_by_filter(
         &self,
         board_key: &str,
         keyword: Option<&str>,
-        range: (Option<chrono::DateTime<Utc>>, Option<chrono::DateTime<Utc>>),
+        range: (
+            Option<chrono::DateTime<chrono::Utc>>,
+            Option<chrono::DateTime<chrono::Utc>>,
+        ),
         page: u64,
         limit: u64,
     ) -> anyhow::Result<Vec<Thread>> {
-        let pool = &self.0;
+        let Some(board_id) = self.board_id_by_key(board_key).await? else {
+            return Ok(Vec::new());
+        };
 
-        let mut query = r#"
-            SELECT
-                *
-            FROM
-                archived_threads
-            WHERE
-                board_id = (
-                    SELECT
-                        id
-                    FROM
-                        boards
-                    WHERE
-                        board_key = ?
-                )
-            "#
-        .to_string();
-
-        if keyword.is_some() {
-            query.push_str("AND title LIKE ? ");
-        }
-
-        if matches!(range, (Some(_), Some(_))) {
-            query.push_str("AND last_modified_at BETWEEN ? AND ? ");
-        }
-
-        query.push_str("ORDER BY last_modified_at DESC ");
-        query.push_str("LIMIT ? OFFSET ?");
-
-        // Dynamic part is only fixed clause fragments / `?` counts; values are bound below.
-        let mut query = sqlx::query_as::<_, SelectionThread>(sqlx::AssertSqlSafe(query));
-
-        query = query.bind(board_key);
+        let mut query =
+            archived_thread::Entity::find().filter(archived_thread::Column::BoardId.eq(board_id));
         if let Some(keyword) = keyword {
-            query = query.bind(format!("%{}%", keyword));
+            query = query.filter(archived_thread::Column::Title.contains(keyword));
         }
         if let (Some(start), Some(end)) = range {
-            query = query.bind(start).bind(end);
+            query = query.filter(
+                archived_thread::Column::LastModifiedAt.between(start.naive_utc(), end.naive_utc()),
+            );
         }
-        query = query.bind(limit).bind(page * limit);
 
-        let selected_threads = query.fetch_all(pool).await?;
-        Ok(selected_threads
+        query
+            .order_by_desc(archived_thread::Column::LastModifiedAt)
+            .limit(limit)
+            .offset(page.saturating_mul(limit))
+            .all(&self.0)
+            .await?
             .into_iter()
-            .map(selection_thread_to_thread)
-            .collect())
+            .map(into_archived_thread)
+            .collect()
     }
 
     async fn compact_threads(&self, board_key: &str, target_count: u32) -> anyhow::Result<()> {
-        sqlx::query!(
-            r#"
-            UPDATE threads SET archived = 1, active = 0 WHERE id IN (
-                SELECT id FROM (
-                    SELECT id
-                    FROM threads
-                    WHERE board_id = (SELECT id FROM boards WHERE board_key = ?)
-                    AND archived = 0
-                    ORDER BY last_modified_at DESC
-                    LIMIT 1000000 OFFSET ?
-                ) AS tmp
-            )
-            "#,
-            board_key,
-            target_count,
-        )
-        .execute(&self.0)
-        .await?;
+        let Some(board_id) = self.board_id_by_key(board_key).await? else {
+            return Ok(());
+        };
+
+        let ids = thread::Entity::find()
+            .select_only()
+            .column(thread::Column::Id)
+            .filter(thread::Column::BoardId.eq(board_id))
+            .filter(thread::Column::Archived.eq(false))
+            .order_by_desc(thread::Column::LastModifiedAt)
+            .offset(u64::from(target_count))
+            .limit(1_000_000)
+            .into_model::<ThreadId>()
+            .all(&self.0)
+            .await?
+            .into_iter()
+            .map(|row| row.id)
+            .collect::<Vec<_>>();
+
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        thread::Entity::update_many()
+            .col_expr(thread::Column::Archived, Expr::value(true))
+            .col_expr(thread::Column::Active, Expr::value(false))
+            .filter(thread::Column::Id.is_in(ids))
+            .exec(&self.0)
+            .await?;
 
         Ok(())
     }
@@ -259,35 +230,27 @@ impl AdminThreadRepository for AdminThreadRepositoryImpl {
         if thread_numbers.is_empty() {
             return Ok(());
         }
-
-        let placeholders = thread_numbers
+        let Some(board_id) = self.board_id_by_key(board_key).await? else {
+            return Ok(());
+        };
+        let thread_numbers = thread_numbers
             .iter()
-            .map(|_| "?")
-            .collect::<Vec<_>>()
-            .join(", ");
-        let query = format!(
-            r#"
-            UPDATE threads
-            SET archived = 1, active = 0
-            WHERE board_id = (
-                SELECT id
-                FROM boards
-                WHERE board_key = ?
-            )
-            AND archived = 0
-            AND thread_number IN ({placeholders})
-            "#
-        );
+            .copied()
+            .map(|value| {
+                i64::try_from(value)
+                    .map_err(|_| anyhow::anyhow!("thread number is too large: {value}"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
-        // Dynamic part is only the fixed number of parameter placeholders; values are bound below.
-        let mut query = sqlx::query(sqlx::AssertSqlSafe(query)).bind(board_key);
-        for thread_number in thread_numbers {
-            query = query.bind(thread_number);
-        }
-        query.execute(&self.0).await?;
+        thread::Entity::update_many()
+            .col_expr(thread::Column::Archived, Expr::value(true))
+            .col_expr(thread::Column::Active, Expr::value(false))
+            .filter(thread::Column::BoardId.eq(board_id))
+            .filter(thread::Column::Archived.eq(false))
+            .filter(thread::Column::ThreadNumber.is_in(thread_numbers))
+            .exec(&self.0)
+            .await?;
 
         Ok(())
     }
 }
-
-transaction_repository!(AdminThreadRepositoryImpl, 0, MySql);


### PR DESCRIPTION
Migrate admin thread listing, archive, compact, and archived-thread lookups to SeaORM. Model the archived thread composite key explicitly and keep query behavior unchanged.