### PR TITLE
refactor(admin): remove MySQL-specific connection setup

### DIFF
--- a/eddist-admin/src/db_time.rs
+++ b/eddist-admin/src/db_time.rs
@@ -1,0 +1,33 @@
+use chrono::{NaiveDateTime, Timelike, Utc};
+
+/// The schema stores timestamps with millisecond precision (`DATETIME(3)`).
+///
+/// Truncating before binding keeps MySQL from rounding a value at the column
+/// boundary and makes the same application value portable to PostgreSQL.
+pub(crate) fn truncate_to_millis(value: NaiveDateTime) -> NaiveDateTime {
+    value
+        .with_nanosecond(value.nanosecond() / 1_000_000 * 1_000_000)
+        .expect("millisecond precision is a valid nanosecond value")
+}
+
+pub(crate) fn now() -> NaiveDateTime {
+    truncate_to_millis(Utc::now().naive_utc())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncates_to_schema_precision() {
+        let value =
+            NaiveDateTime::parse_from_str("2026-09-12 12:34:56.123987", "%Y-%m-%d %H:%M:%S%.f")
+                .unwrap();
+
+        assert_eq!(
+            truncate_to_millis(value),
+            NaiveDateTime::parse_from_str("2026-09-12 12:34:56.123", "%Y-%m-%d %H:%M:%S%.f",)
+                .unwrap()
+        );
+    }
+}

--- a/eddist-admin/src/integration_tests.rs
+++ b/eddist-admin/src/integration_tests.rs
@@ -84,7 +84,7 @@ fn create_board_input(board_key: &str, name: &str) -> CreateBoardInput {
 }
 
 async fn insert_authed_token(db: &DatabaseConnection, id: Uuid) -> anyhow::Result<()> {
-    let now = Utc::now().naive_utc();
+    let now = crate::db_time::now();
     authed_token::ActiveModel {
         id: Set(id),
         token: Set(format!("integration-token-{id}")),
@@ -174,7 +174,7 @@ async fn insert_archived_thread_and_response(
 ) -> anyhow::Result<(Uuid, Uuid)> {
     let thread_id = Uuid::now_v7();
     let response_id = Uuid::now_v7();
-    let timestamp = Utc::now().naive_utc();
+    let timestamp = crate::db_time::now();
 
     archived_thread::Entity::insert(archived_thread::ActiveModel {
         id: Set(thread_id),
@@ -278,7 +278,7 @@ async fn seaorm_admin_crud_round_trips_against_mysql() -> anyhow::Result<()> {
     insert_authed_token(db, token_id).await?;
     let thread_id = Uuid::now_v7();
     let second_thread_id = Uuid::now_v7();
-    let now = Utc::now().naive_utc();
+    let now = crate::db_time::now();
     insert_thread(db, thread_id, board.id, token_id, 1001, now).await?;
     insert_thread(
         db,

--- a/eddist-admin/src/integration_tests.rs
+++ b/eddist-admin/src/integration_tests.rs
@@ -289,6 +289,22 @@ async fn seaorm_admin_crud_round_trips_against_mysql() -> anyhow::Result<()> {
         now + Duration::seconds(1),
     )
     .await?;
+    // Boards with no threads must still be returned, with a zero count: the thread counts come
+    // from a GROUP BY that omits them entirely.
+    let all_boards = board_repository.get_boards_by_key(None).await?;
+    let counts = all_boards
+        .iter()
+        .map(|board| (board.board_key.as_str(), board.thread_count))
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counts.get("orm-it").copied(), Some(2));
+    assert_eq!(counts.get("orm-it-2").copied(), Some(0));
+
+    let filtered_boards = board_repository
+        .get_boards_by_key(Some(vec!["orm-it".to_string()]))
+        .await?;
+    assert_eq!(filtered_boards.len(), 1);
+    assert_eq!(filtered_boards[0].thread_count, 2);
+
     let response_id = Uuid::now_v7();
     insert_response(db, response_id, board.id, thread_id, token_id, now).await?;
     let (_, archived_response_id) =

--- a/eddist-admin/src/main.rs
+++ b/eddist-admin/src/main.rs
@@ -46,6 +46,7 @@ use tracing::info_span;
 
 mod api_doc;
 mod auth;
+mod db_time;
 pub(crate) mod entity;
 pub(crate) mod error;
 #[cfg(test)]
@@ -211,22 +212,7 @@ async fn main() {
         .not_found_service(ServeFile::new(format!("{serve_dir}/index.html")));
 
     let mut connect_options = sea_orm::ConnectOptions::new(std::env::var("DATABASE_URL").unwrap());
-    connect_options
-        .sqlx_logging(false)
-        .map_sqlx_mysql_pool_opts(|pool_options| {
-            pool_options.after_connect(|conn, _| {
-                use sea_orm::sqlx::Executor;
-
-                Box::pin(async move {
-                    conn.execute(
-                        "SET SESSION sql_mode = CONCAT(@@sql_mode, ',TIME_TRUNCATE_FRACTIONAL')",
-                    )
-                    .await?;
-                    log::info!("Set TIME_TRUNCATE_FRACTIONAL mode");
-                    Ok(())
-                })
-            })
-        });
+    connect_options.sqlx_logging(false);
     let orm_db = sea_orm::Database::connect(connect_options).await.unwrap();
 
     let r2_account_id = env::var("R2_ACCOUNT_ID").unwrap();

--- a/eddist-admin/src/repository/admin_board_repository.rs
+++ b/eddist-admin/src/repository/admin_board_repository.rs
@@ -25,8 +25,9 @@ impl AdminBoardRepositoryImpl {
 }
 
 #[derive(Debug, FromQueryResult)]
-struct ThreadBoardId {
+struct ThreadCountByBoard {
     board_id: Uuid,
+    thread_count: i64,
 }
 
 fn into_board(model: board::Model, thread_count: i64) -> Board {
@@ -90,16 +91,19 @@ impl AdminBoardRepository for AdminBoardRepositoryImpl {
             .all(&self.0)
             .await?;
 
-        let thread_board_ids = thread::Entity::find()
+        let board_ids = models.iter().map(|model| model.id).collect::<Vec<_>>();
+        let thread_counts = thread::Entity::find()
             .select_only()
             .column(thread::Column::BoardId)
-            .into_model::<ThreadBoardId>()
+            .column_as(thread::Column::Id.count(), "thread_count")
+            .filter(thread::Column::BoardId.is_in(board_ids))
+            .group_by(thread::Column::BoardId)
+            .into_model::<ThreadCountByBoard>()
             .all(&self.0)
-            .await?;
-        let mut thread_counts = HashMap::<Uuid, i64>::new();
-        for row in thread_board_ids {
-            *thread_counts.entry(row.board_id).or_default() += 1;
-        }
+            .await?
+            .into_iter()
+            .map(|row| (row.board_id, row.thread_count))
+            .collect::<HashMap<_, _>>();
 
         Ok(models
             .into_iter()

--- a/eddist-admin/src/repository/admin_board_repository.rs
+++ b/eddist-admin/src/repository/admin_board_repository.rs
@@ -121,7 +121,7 @@ impl AdminBoardRepository for AdminBoardRepositoryImpl {
     async fn create_board(&self, board: CreateBoardInput) -> anyhow::Result<Board> {
         let board_id = Uuid::now_v7();
         let board_key = board.board_key.clone();
-        let now = chrono::Utc::now().naive_utc();
+        let now = crate::db_time::now();
         let tx = self.0.begin().await?;
 
         board::ActiveModel {

--- a/eddist-admin/src/repository/admin_user_repository.rs
+++ b/eddist-admin/src/repository/admin_user_repository.rs
@@ -1,7 +1,8 @@
 use crate::entity::{authed_token, idp, user, user_authed_token, user_idp_binding};
+use sea_orm::sea_query::Expr;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, Condition, DatabaseConnection, EntityTrait,
-    QueryFilter, QueryOrder, TransactionTrait,
+    ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
+    TransactionTrait,
 };
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -137,26 +138,25 @@ impl AdminUserRepository for AdminUserRepositoryImpl {
     async fn update_user_status(&self, user_id: Uuid, enabled: bool) -> anyhow::Result<()> {
         let tx = self.0.begin().await?;
 
-        user::ActiveModel {
-            id: Set(user_id),
-            enabled: Set(enabled),
-            ..Default::default()
-        }
-        .update(&tx)
-        .await?;
+        user::Entity::update_many()
+            .col_expr(user::Column::Enabled, Expr::value(enabled))
+            .filter(user::Column::Id.eq(user_id))
+            .exec(&tx)
+            .await?;
 
-        let token_relations = user_authed_token::Entity::find()
+        let token_ids = user_authed_token::Entity::find()
             .filter(user_authed_token::Column::UserId.eq(user_id))
             .all(&tx)
-            .await?;
-        for relation in token_relations {
-            authed_token::ActiveModel {
-                id: Set(relation.authed_token_id),
-                validity: Set(enabled),
-                ..Default::default()
-            }
-            .update(&tx)
-            .await?;
+            .await?
+            .into_iter()
+            .map(|relation| relation.authed_token_id)
+            .collect::<Vec<_>>();
+        if !token_ids.is_empty() {
+            authed_token::Entity::update_many()
+                .col_expr(authed_token::Column::Validity, Expr::value(enabled))
+                .filter(authed_token::Column::Id.is_in(token_ids))
+                .exec(&tx)
+                .await?;
         }
 
         tx.commit().await?;

--- a/eddist-admin/src/repository/authed_token_repository.rs
+++ b/eddist-admin/src/repository/authed_token_repository.rs
@@ -2,8 +2,8 @@ use crate::entity::authed_token;
 use crate::models::AuthedToken;
 use sea_orm::sea_query::Expr;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait,
-    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect,
+    ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
+    QuerySelect,
 };
 use uuid::Uuid;
 
@@ -38,6 +38,18 @@ pub struct AuthedTokenRepositoryImpl(DatabaseConnection);
 impl AuthedTokenRepositoryImpl {
     pub fn new(db: DatabaseConnection) -> Self {
         Self(db)
+    }
+
+    async fn update_require_reauth(&self, id: Uuid, require_reauth: bool) -> anyhow::Result<()> {
+        authed_token::Entity::update_many()
+            .col_expr(
+                authed_token::Column::RequireReauth,
+                Expr::value(require_reauth),
+            )
+            .filter(authed_token::Column::Id.eq(id))
+            .exec(&self.0)
+            .await?;
+        Ok(())
     }
 }
 
@@ -74,13 +86,11 @@ impl AuthedTokenRepository for AuthedTokenRepositoryImpl {
     }
 
     async fn delete_authed_token(&self, id: Uuid) -> anyhow::Result<()> {
-        authed_token::ActiveModel {
-            id: Set(id),
-            validity: Set(false),
-            ..Default::default()
-        }
-        .update(&self.0)
-        .await?;
+        authed_token::Entity::update_many()
+            .col_expr(authed_token::Column::Validity, Expr::value(false))
+            .filter(authed_token::Column::Id.eq(id))
+            .exec(&self.0)
+            .await?;
         Ok(())
     }
 
@@ -175,24 +185,10 @@ impl AuthedTokenRepository for AuthedTokenRepositoryImpl {
     }
 
     async fn set_require_reauth(&self, id: Uuid) -> anyhow::Result<()> {
-        authed_token::ActiveModel {
-            id: Set(id),
-            require_reauth: Set(true),
-            ..Default::default()
-        }
-        .update(&self.0)
-        .await?;
-        Ok(())
+        self.update_require_reauth(id, true).await
     }
 
     async fn clear_require_reauth(&self, id: Uuid) -> anyhow::Result<()> {
-        authed_token::ActiveModel {
-            id: Set(id),
-            require_reauth: Set(false),
-            ..Default::default()
-        }
-        .update(&self.0)
-        .await?;
-        Ok(())
+        self.update_require_reauth(id, false).await
     }
 }

--- a/eddist-admin/src/repository/cap_repository.rs
+++ b/eddist-admin/src/repository/cap_repository.rs
@@ -99,7 +99,7 @@ impl CapRepository for CapRepositoryImpl {
         password_hash: &str,
     ) -> anyhow::Result<Cap> {
         let id = Uuid::now_v7();
-        let now = chrono::Utc::now().naive_utc();
+        let now = crate::db_time::now();
         let model = cap::ActiveModel {
             id: Set(id),
             name: Set(name.to_string()),
@@ -139,7 +139,7 @@ impl CapRepository for CapRepositoryImpl {
             anyhow::bail!("cap not found: {id}");
         }
 
-        let now = chrono::Utc::now().naive_utc();
+        let now = crate::db_time::now();
         let mut active_model = cap::ActiveModel {
             id: Set(id),
             updated_at: Set(now),

--- a/eddist-admin/src/repository/captcha_config_repository.rs
+++ b/eddist-admin/src/repository/captcha_config_repository.rs
@@ -1,5 +1,4 @@
 use crate::entity::captcha_config;
-use chrono::Utc;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
     QueryOrder,
@@ -126,7 +125,7 @@ impl CaptchaConfigRepository for CaptchaConfigRepositoryImpl {
         updated_by: Option<String>,
     ) -> anyhow::Result<CaptchaConfig> {
         let id = Uuid::now_v7();
-        let now = Utc::now().naive_utc();
+        let now = crate::db_time::now();
 
         let capture_fields = serde_json::to_value(&input.capture_fields)?;
         let verification = input
@@ -169,7 +168,7 @@ impl CaptchaConfigRepository for CaptchaConfigRepositoryImpl {
         input: UpdateCaptchaConfigInput,
         updated_by: Option<String>,
     ) -> anyhow::Result<CaptchaConfig> {
-        let now = Utc::now().naive_utc();
+        let now = crate::db_time::now();
         let current = self.get_by_id(id).await?.ok_or_else(|| {
             crate::error::ServiceError::NotFound("Captcha config not found".into())
         })?;

--- a/eddist-admin/src/repository/ngword_repository.rs
+++ b/eddist-admin/src/repository/ngword_repository.rs
@@ -88,7 +88,7 @@ impl NgWordRepository for NgWordRepositoryImpl {
 
     async fn create_ng_word(&self, name: &str, word: &str) -> anyhow::Result<NgWord> {
         let id = Uuid::now_v7();
-        let now = chrono::Utc::now().naive_utc();
+        let now = crate::db_time::now();
         let model = ng_word::ActiveModel {
             id: Set(id),
             name: Set(name.to_string()),
@@ -130,7 +130,7 @@ impl NgWordRepository for NgWordRepositoryImpl {
             anyhow::bail!("ng word not found: {id}");
         }
 
-        let now = chrono::Utc::now().naive_utc();
+        let now = crate::db_time::now();
         let mut active_model = ng_word::ActiveModel {
             id: Set(id),
             updated_at: Set(now),

--- a/eddist-admin/src/repository/notice_repository.rs
+++ b/eddist-admin/src/repository/notice_repository.rs
@@ -1,5 +1,5 @@
 use crate::entity::notice;
-use chrono::{NaiveDateTime, Utc};
+use chrono::NaiveDateTime;
 use eddist_core::domain::notice::Notice;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
@@ -107,7 +107,7 @@ impl NoticeRepository for NoticeRepositoryImpl {
         }
 
         let id = Uuid::now_v7();
-        let now = Utc::now().naive_utc();
+        let now = crate::db_time::now();
 
         let model = notice::ActiveModel {
             id: Set(id),
@@ -116,7 +116,7 @@ impl NoticeRepository for NoticeRepositoryImpl {
             content: Set(input.content),
             created_at: Set(now),
             updated_at: Set(now),
-            published_at: Set(input.published_at),
+            published_at: Set(crate::db_time::truncate_to_millis(input.published_at)),
             author_email: Set(author_email),
             hide_from_list: Set(input.hide_from_list),
         }
@@ -127,7 +127,7 @@ impl NoticeRepository for NoticeRepositoryImpl {
     }
 
     async fn update_notice(&self, id: Uuid, input: UpdateNoticeInput) -> anyhow::Result<Notice> {
-        let now = Utc::now().naive_utc();
+        let now = crate::db_time::now();
 
         let current = self
             .get_notice_by_id(id)
@@ -136,7 +136,8 @@ impl NoticeRepository for NoticeRepositoryImpl {
 
         let title = input.title.clone().unwrap_or_else(|| current.title.clone());
         let content = input.content.unwrap_or(current.content);
-        let published_at = input.published_at.unwrap_or(current.published_at);
+        let published_at =
+            crate::db_time::truncate_to_millis(input.published_at.unwrap_or(current.published_at));
         let hide_from_list = input.hide_from_list.unwrap_or(current.hide_from_list);
 
         let new_slug = if let Some(custom_slug) = input.slug {

--- a/eddist-admin/src/repository/server_settings_repository.rs
+++ b/eddist-admin/src/repository/server_settings_repository.rs
@@ -1,5 +1,4 @@
 use crate::entity::server_settings;
-use chrono::Utc;
 use eddist_core::{server_settings::KEY_AI_OPENAI_API_KEY, symmetric};
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{
@@ -71,7 +70,7 @@ impl ServerSettingsRepository for ServerSettingsRepositoryImpl {
 
     async fn upsert(&self, input: UpsertServerSettingInput) -> anyhow::Result<ServerSetting> {
         let id = Uuid::now_v7();
-        let now = Utc::now().naive_utc();
+        let now = crate::db_time::now();
 
         let should_encrypt = input.setting_key == KEY_AI_OPENAI_API_KEY;
         let value = if should_encrypt {

--- a/eddist-admin/src/repository/terms_repository.rs
+++ b/eddist-admin/src/repository/terms_repository.rs
@@ -1,5 +1,4 @@
 use crate::entity::terms;
-use chrono::Utc;
 use eddist_core::domain::terms::Terms;
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, EntityTrait, QueryOrder};
 
@@ -52,7 +51,7 @@ impl TermsRepository for TermsRepositoryImpl {
         input: UpdateTermsInput,
         updated_by: Option<String>,
     ) -> anyhow::Result<Terms> {
-        let now = Utc::now().naive_utc();
+        let now = crate::db_time::now();
 
         let current = self
             .get_terms()

--- a/eddist-admin/src/repository/user_restriction_repository.rs
+++ b/eddist-admin/src/repository/user_restriction_repository.rs
@@ -65,13 +65,15 @@ impl UserRestrictionRepository for UserRestrictionRepositoryImpl {
         input: CreateUserRestrictionRuleInput,
     ) -> anyhow::Result<UserRestrictionRule> {
         let id = Uuid::now_v7();
-        let now = chrono::Utc::now().naive_utc();
+        let now = crate::db_time::now();
         let model = user_restriction::ActiveModel {
             id: Set(id),
             name: Set(input.name),
             rule_type: Set(input.rule_type.as_str().to_string()),
             rule_value: Set(input.rule_value),
-            expires_at: Set(input.expires_at.map(|date_time| date_time.naive_utc())),
+            expires_at: Set(input
+                .expires_at
+                .map(|date_time| crate::db_time::truncate_to_millis(date_time.naive_utc()))),
             created_at: Set(now),
             updated_at: Set(now),
             created_by_email: Set(input.created_by_email),
@@ -83,7 +85,7 @@ impl UserRestrictionRepository for UserRestrictionRepositoryImpl {
     }
 
     async fn update_rule(&self, input: UpdateUserRestrictionRuleInput) -> anyhow::Result<()> {
-        let now = chrono::Utc::now().naive_utc();
+        let now = crate::db_time::now();
         let current = self
             .get_rule_by_id(input.id)
             .await?
@@ -99,7 +101,8 @@ impl UserRestrictionRepository for UserRestrictionRepositoryImpl {
             name: Set(name),
             rule_type: Set(rule_type.as_str().to_string()),
             rule_value: Set(rule_value),
-            expires_at: Set(expires_at.map(|date_time| date_time.naive_utc())),
+            expires_at: Set(expires_at
+                .map(|date_time| crate::db_time::truncate_to_millis(date_time.naive_utc()))),
             updated_at: Set(now),
             ..Default::default()
         }


### PR DESCRIPTION
Remove the MySQL-specific connection hook from eddist-admin and normalize DATETIME(3) values in application code. Keep the SeaORM connection boundary backend-neutral for future PostgreSQL validation.